### PR TITLE
Added Import functionality to variables command

### DIFF
--- a/cmd/variable/action/import.go
+++ b/cmd/variable/action/import.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"errors"
-	"fmt"
 
 	"bunnyshell.com/cli/pkg/api/variable"
 	"bunnyshell.com/cli/pkg/config"

--- a/cmd/variable/action/import.go
+++ b/cmd/variable/action/import.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"errors"
+	"fmt"
 
 	"bunnyshell.com/cli/pkg/api/variable"
 	"bunnyshell.com/cli/pkg/config"
@@ -59,7 +60,7 @@ func init() {
 				for key, value := range data.Vars {
 					err := createEnvVar(cmd, key, value, false)
 					if err != nil {
-						if ignoreDuplicates && err.Error() == "An Environment Variable with this name already exists in this environment." {
+						if ignoreDuplicates && err.Error() == "An error occurred: name: An Environment Variable with this name already exists in this environment." {
 							continue
 						} else {
 							return lib.FormatCommandError(cmd, err)
@@ -72,7 +73,7 @@ func init() {
 				for key, value := range data.Secrets {
 					err := createEnvVar(cmd, key, value, true)
 					if err != nil {
-						if ignoreDuplicates && err.Error() == "An Environment Variable with this name already exists in this environment." {
+						if ignoreDuplicates && err.Error() == "An error occurred: name: An Environment Variable with this name already exists in this environment." {
 							continue
 						} else {
 							return lib.FormatCommandError(cmd, err)
@@ -89,7 +90,7 @@ func init() {
 
 	flags.StringVar(&varFile, "vars-file", varFile, "File to import variables from")
 	flags.StringVar(&secretFile, "secrets-file", secretFile, "File to import secrets from")
-	flags.BoolVarP(&ignoreDuplicates, "ignore-duplicates", "ign-dp", false, "Skip variables that already exist in the environment")
+	flags.BoolVarP(&ignoreDuplicates, "ignore-duplicates", "", false, "Skip variables that already exist in the environment")
 
 	flags.AddFlag(options.Environment.AddFlagWithExtraHelp(
 		"environment",

--- a/cmd/variable/action/import.go
+++ b/cmd/variable/action/import.go
@@ -57,26 +57,16 @@ func init() {
 
 			if len(data.Vars) > 0 {
 				for key, value := range data.Vars {
-					err := createEnvVar(cmd, key, value, false)
-					if err != nil {
-						if ignoreDuplicates && err.Error() == "An error occurred: name: An Environment Variable with this name already exists in this environment." {
-							continue
-						} else {
-							return lib.FormatCommandError(cmd, err)
-						}
+					if err := createEnvVar(cmd, key, value, false, ignoreDuplicates); err != nil {
+						return lib.FormatCommandError(cmd, err)
 					}
 				}
 			}
 
 			if len(data.Secrets) > 0 {
 				for key, value := range data.Secrets {
-					err := createEnvVar(cmd, key, value, true)
-					if err != nil {
-						if ignoreDuplicates && err.Error() == "An error occurred: name: An Environment Variable with this name already exists in this environment." {
-							continue
-						} else {
-							return lib.FormatCommandError(cmd, err)
-						}
+					if err := createEnvVar(cmd, key, value, true, ignoreDuplicates); err != nil {
+						return lib.FormatCommandError(cmd, err)
 					}
 				}
 			}
@@ -121,23 +111,27 @@ func readFile(fileName string, data *map[string]string) error {
 	return nil
 }
 
-func createEnvVar(cmd *cobra.Command, name string, value string, isSecret bool) error {
+func createEnvVar(cmd *cobra.Command, name string, value string, isSecret bool, ignoreDuplicates bool) error {
 	settings := config.GetSettings()
 	createOptions := variable.NewCreateOptions()
 	createOptions.Environment = settings.Profile.Context.Environment
 	createOptions.Name = name
 	createOptions.Value = value
-	if isSecret {
+	if isSecret  {
 		createOptions.IsSecret = enum.BoolTrue
 	}
 
 	model, err := variable.Create(createOptions)
 
-	if err != nil {
-		return err
-	} else {
+	if err == nil {
 		lib.FormatCommandData(cmd, model)
+
+		return nil
+	} 
+
+	if ignoreDuplicates && err.Error() == "An error occurred: name: An Environment Variable with this name already exists in this environment." {
+		return nil
 	}
 
-	return nil 
+	return err
 }

--- a/cmd/variable/action/import.go
+++ b/cmd/variable/action/import.go
@@ -1,0 +1,134 @@
+package action
+
+import (
+	"errors"
+	"fmt"
+
+	"bunnyshell.com/cli/pkg/api/variable"
+	"bunnyshell.com/cli/pkg/config"
+	"bunnyshell.com/cli/pkg/config/enum"
+	"bunnyshell.com/cli/pkg/lib"
+	"bunnyshell.com/cli/pkg/util"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type BulkImport struct {
+	Vars    map[string]string `json:"vars" yaml:"vars"`
+	Secrets map[string]string `json:"secrets" yaml:"secrets"`
+}
+
+func init() {
+	varFile := ""
+	secretFile := ""
+	options := config.GetOptions()
+	data := BulkImport{
+		Vars:    make(map[string]string),
+		Secrets: make(map[string]string),
+	}
+
+	command := &cobra.Command{
+		Use: "import",
+
+		ValidArgsFunction: cobra.NoFileCompletions,
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			//todo add this to preRunE
+			if varFile == "" && secretFile == "" {
+				return errors.New("must provide a either a var or secret file")
+			}
+
+			if varFile != "" {
+				if err := readFile(varFile, &data.Vars); err != nil {
+					return err
+				}
+			}
+
+			if secretFile != "" {
+				if err := readFile(secretFile, &data.Secrets); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			settings := config.GetSettings()
+
+			if len(data.Vars) > 0 {
+				for key, value := range data.Vars {
+					createOptions := variable.NewCreateOptions()
+					createOptions.Environment = settings.Profile.Context.Environment
+					createOptions.Name = key
+					createOptions.Value = value
+
+					model, err := variable.Create(createOptions)
+					if err != nil {
+						// Log the error or notify that the particular variable couldn't be created
+						fmt.Printf("Error creating variable %s: %v\n", key, err)
+					} else {
+						// Successfully created model, output the results immediately
+						lib.FormatCommandData(cmd, model)
+					}
+				}
+			}
+
+			if len(data.Secrets) > 0 {
+				for key, value := range data.Secrets {
+					createOptions := variable.NewCreateOptions()
+					createOptions.Environment = settings.Profile.Context.Environment
+					createOptions.Name = key
+					createOptions.Value = value
+					createOptions.IsSecret = enum.BoolTrue
+					model, err := variable.Create(createOptions)
+					if err != nil {
+						// Log the error or notify that the particular variable couldn't be created
+						fmt.Printf("Error creating variable %s: %v\n", key, err)
+					} else {
+						// Successfully created model, output the results immediately
+						lib.FormatCommandData(cmd, model)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+
+	flags := command.Flags()
+
+	flags.StringVar(&varFile, "vars-file", varFile, "File to import variables from")
+	flags.StringVar(&secretFile, "secrets-file", secretFile, "File to import secrets from")
+
+	flags.AddFlag(options.Environment.AddFlagWithExtraHelp(
+		"environment",
+		"Environment for the variable",
+		"Environments contain multiple variables",
+		util.FlagRequired,
+	))
+
+	// createOptions.UpdateFlagSet(flags)
+
+	mainCmd.AddCommand(command)
+}
+
+func readFile(fileName string, data *map[string]string) error {
+	viper := viper.New()
+	viper.SetConfigFile(fileName)
+	viper.SetConfigType("env")
+
+	if err := viper.ReadInConfig(); err != nil {
+		// @review update go:1.20 errors.join
+		// return fmt.Errorf("%w: %s", ErrConfigLoad, err.Error())
+		return err
+	}
+
+	if err := viper.Unmarshal(&data); err != nil {
+		// @review update go:1.20 errors.join
+		// return fmt.Errorf("%w: %s", ErrConfigLoad, err.Error())
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Added import functionality to bns variables command

bns variables import --vars-file /path/to/vars-file --secrets-file /path/to/secrets-file

# vars-file or secrets-file structure
VAR=VAL
VAR2=VAL2

# vars file and secrets file directive can be included individual where needed.
bns variables import --vars-file /path/to/vars-file
bns variables import --secrets-file /path/to/secrets-file

This only imports non-existent keys (no update or delete or edit)