### PR TITLE
add overwrite-kubeconfig-cluster-server flag for kube related commands

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   audit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,8 +18,8 @@ builds:
   - env:
       - CGO_ENABLED=0
     goos:
-#      - linux
-#      - windows
+      - linux
+      - windows
       - darwin
     flags:
       - -trimpath

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,8 +18,8 @@ builds:
   - env:
       - CGO_ENABLED=0
     goos:
-      - linux
-      - windows
+#      - linux
+#      - windows
       - darwin
     flags:
       - -trimpath

--- a/cmd/component/action/port_forward.go
+++ b/cmd/component/action/port_forward.go
@@ -18,8 +18,9 @@ func init() {
 	settings := config.GetSettings()
 
 	var (
-		resourcePath string
-		podName      string
+		resourcePath          string
+		podName               string
+		overrideClusterServer string
 	)
 
 	command := &cobra.Command{
@@ -54,6 +55,10 @@ func init() {
 
 			portForwardManager.WithPortMappings(portMappings)
 
+			if overrideClusterServer != "" {
+				portForwardManager.WithOverrideClusterServer(overrideClusterServer)
+			}
+
 			environmentResource, err := environment.NewFromWizard(&settings.Profile.Context, resourcePath)
 			if err != nil {
 				return err
@@ -61,6 +66,7 @@ func init() {
 
 			_ = portForwardManager.
 				WithEnvironmentResource(environmentResource).
+				WithWorkspace().
 				PrepareKubernetesClient()
 
 			if podName != "" {
@@ -88,6 +94,7 @@ func init() {
 
 	flags.StringVarP(&resourcePath, "resource", "s", "", "The cluster resource to use (namespace/kind/name format).")
 	flags.StringVar(&podName, "pod", "", "The resource pod to forward ports to.")
+	flags.StringVar(&overrideClusterServer, "override-kubeconfig-cluster-server", "", "Override kubeconfig cluster server with :port, host:port or scheme://host:port")
 
 	mainCmd.AddCommand(command)
 }

--- a/cmd/component/action/ssh.go
+++ b/cmd/component/action/ssh.go
@@ -26,6 +26,8 @@ type SSHOptions struct {
 
 	NoTTY    bool
 	NoBanner bool
+
+	OverrideClusterServer string
 }
 
 func (o *SSHOptions) UpdateFlagSet(flags *pflag.FlagSet) {
@@ -35,6 +37,8 @@ func (o *SSHOptions) UpdateFlagSet(flags *pflag.FlagSet) {
 
 	flags.BoolVar(&o.NoTTY, "no-tty", o.NoTTY, "Do not allocate a TTY")
 	flags.BoolVar(&o.NoBanner, "no-banner", o.NoBanner, "Do not show environment banner before ssh")
+
+	flags.StringVar(&o.OverrideClusterServer, "override-kubeconfig-cluster-server", o.OverrideClusterServer, "Override kubeconfig cluster server with :port, host:port or scheme://host:port")
 }
 
 func (o *SSHOptions) MakeExecOptions(kubeConfig *environment.KubeConfigItem) *k8sExec.Options {
@@ -63,7 +67,8 @@ func init() {
 	settings := config.GetSettings()
 
 	sshOptions := SSHOptions{
-		Shell: "/bin/sh",
+		Shell:                 "/bin/sh",
+		OverrideClusterServer: "",
 	}
 
 	command := &cobra.Command{
@@ -78,7 +83,7 @@ func init() {
 				return err
 			}
 
-			kubeConfigOptions := environment.NewKubeConfigOptions(componentItem.GetEnvironment())
+			kubeConfigOptions := environment.NewKubeConfigOptions(componentItem.GetEnvironment(), sshOptions.OverrideClusterServer)
 			kubeConfig, err := environment.KubeConfig(kubeConfigOptions)
 			if err != nil {
 				return err

--- a/cmd/component_debug/ssh.go
+++ b/cmd/component_debug/ssh.go
@@ -9,6 +9,8 @@ type SSHOptions struct {
 
 	NoTTY    bool
 	NoBanner bool
+
+	OverrideClusterServer string
 }
 
 func (o *SSHOptions) UpdateFlagSet(flags *pflag.FlagSet) {

--- a/cmd/component_debug/up.go
+++ b/cmd/component_debug/up.go
@@ -1,13 +1,13 @@
 package component_debug
 
 import (
-    "fmt"
+	"fmt"
 
 	"bunnyshell.com/cli/pkg/config"
-	"bunnyshell.com/cli/pkg/k8s/bridge"
-	"bunnyshell.com/cli/pkg/lib"
 	"bunnyshell.com/cli/pkg/debug_component/action"
 	upAction "bunnyshell.com/cli/pkg/debug_component/action/up"
+	"bunnyshell.com/cli/pkg/k8s/bridge"
+	"bunnyshell.com/cli/pkg/lib"
 	"github.com/spf13/cobra"
 )
 
@@ -16,8 +16,9 @@ func init() {
 	settings := config.GetSettings()
 
 	sshOptions := SSHOptions{
-        Shell: "/bin/sh",
-    }
+		Shell:                 "/bin/sh",
+		OverrideClusterServer: "",
+	}
 
 	resourceLoader := bridge.NewResourceLoader()
 	upOptions := upAction.NewOptions(resourceLoader)
@@ -53,14 +54,15 @@ func init() {
 				return err
 			}
 
-            selectedContainerName, err := upAction.GetSelectedContainerName()
-            if err != nil {
-                return err
-            }
+			selectedContainerName, err := upAction.GetSelectedContainerName()
+			if err != nil {
+				return err
+			}
 
-            if err = startSSH(*resourceLoader.Component.Id, selectedContainerName, sshOptions, cmd, args); err != nil {
-                return fmt.Errorf("debug SSH exited with: %s", err)
-            }
+			sshOptions.OverrideClusterServer = upParameters.OverrideClusterServer
+			if err = startSSH(*resourceLoader.Component.Id, selectedContainerName, sshOptions, cmd, args); err != nil {
+				return fmt.Errorf("debug SSH exited with: %s", err)
+			}
 
 			return upAction.Close()
 		},
@@ -81,31 +83,35 @@ func init() {
 }
 
 func startSSH(componentId string, containerName string, sshOptions SSHOptions, cmd *cobra.Command, args []string) error {
-    proxyArgs := []string{
-        "components", "ssh",
-        "--id", componentId,
-    }
+	proxyArgs := []string{
+		"components", "ssh",
+		"--id", componentId,
+	}
 
-    proxyArgs = append(proxyArgs, "--container", containerName)
+	proxyArgs = append(proxyArgs, "--container", containerName)
 
-    if sshOptions.Shell != "" {
-        proxyArgs = append(proxyArgs, "--shell", sshOptions.Shell)
-    }
+	if sshOptions.Shell != "" {
+		proxyArgs = append(proxyArgs, "--shell", sshOptions.Shell)
+	}
 
-    if sshOptions.NoBanner {
-        proxyArgs = append(proxyArgs, "--no-banner")
-    }
+	if sshOptions.NoBanner {
+		proxyArgs = append(proxyArgs, "--no-banner")
+	}
 
-    if sshOptions.NoTTY {
-        proxyArgs = append(proxyArgs, "--no-tty")
-    }
+	if sshOptions.NoTTY {
+		proxyArgs = append(proxyArgs, "--no-tty")
+	}
 
-    root := cmd.Root()
-    root.SetArgs(append(proxyArgs, args...))
+	if sshOptions.OverrideClusterServer != "" {
+		proxyArgs = append(proxyArgs, "--override-kubeconfig-cluster-server", sshOptions.OverrideClusterServer)
+	}
 
-    if err := root.Execute(); err != nil {
-        return err
-    }
+	root := cmd.Root()
+	root.SetArgs(append(proxyArgs, args...))
 
-    return nil
+	if err := root.Execute(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/template/validate.go
+++ b/cmd/template/validate.go
@@ -150,6 +150,10 @@ func getSource(validateSource ValidateSource, validateOptions template.ValidateO
 			source.SetValidateComponents(true)
 		}
 
+		if !validateOptions.AllowExtraFields {
+			source.SetValidateAllowExtraFields(false)
+		}
+
 		action := sdk.ValidateSourceGitAsTemplateValidateActionSource(source)
 
 		return &action, nil
@@ -170,6 +174,10 @@ func getSource(validateSource ValidateSource, validateOptions template.ValidateO
 		if validateOptions.WithComponents {
 			source.SetValidateComponents(true)
 			source.SetValidateForOrganizationId(validateOptions.Organization)
+		}
+
+		if !validateOptions.AllowExtraFields {
+			source.SetValidateAllowExtraFields(false)
 		}
 
 		action := sdk.ValidateSourceStringAsTemplateValidateActionSource(source)

--- a/cmd/utils/port_forward.go
+++ b/cmd/utils/port_forward.go
@@ -13,8 +13,9 @@ func init() {
 	settings := config.GetSettings()
 
 	var (
-		resourcePath string
-		podName      string
+		resourcePath          string
+		podName               string
+		overrideClusterServer string
 	)
 
 	command := &cobra.Command{
@@ -33,6 +34,7 @@ func init() {
 				"--id", settings.Profile.Context.ServiceComponent,
 				"--resource", resourcePath,
 				"--pod", podName,
+				"--override-kubeconfig-cluster-server", overrideClusterServer,
 			}, portMappings...))
 
 			if err := root.Execute(); err != nil {
@@ -49,6 +51,7 @@ func init() {
 
 	flags.StringVarP(&resourcePath, "resource", "s", "", "The cluster resource to use (namespace/kind/name format).")
 	flags.StringVar(&podName, "pod", "", "The resource pod to forward ports to.")
+	flags.StringVar(&overrideClusterServer, "override-kubeconfig-cluster-server", "", "Override kubeconfig cluster server with :port, host:port or scheme://host:port")
 
 	mainCmd.AddCommand(command)
 }

--- a/cmd/utils/ssh.go
+++ b/cmd/utils/ssh.go
@@ -50,6 +50,10 @@ func init() {
 				proxyArgs = append(proxyArgs, "--no-tty")
 			}
 
+			if sshOptions.OverrideClusterServer != "" {
+				proxyArgs = append(proxyArgs, "--override-kubeconfig-cluster-server", sshOptions.OverrideClusterServer)
+			}
+
 			root := cmd.Root()
 			root.SetArgs(append(proxyArgs, args...))
 

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ toolchain go1.23.2
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 
 require (
-	bunnyshell.com/dev v0.7.1
-	bunnyshell.com/sdk v0.20.1
+	bunnyshell.com/dev v0.7.2
+	bunnyshell.com/sdk v0.20.3
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/avast/retry-go/v4 v4.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-bunnyshell.com/dev v0.7.1 h1:mNLF0h2bbrTi9LNr2e2zFUC2fGg8TUh/9SM5rTXkzDI=
-bunnyshell.com/dev v0.7.1/go.mod h1:+Xk46UXX9AW0nHrFMdO/IwpUPfALrck1/qI+LIXsDmE=
-bunnyshell.com/sdk v0.20.1 h1:YxmYrW8UXGNNtLe+l6pXFKyndgwyEyQtdX0f5rHV1fE=
-bunnyshell.com/sdk v0.20.1/go.mod h1:RfgfUzZ4WHZGCkToUfu2/hoQS6XsQc8IdPTVAlpS138=
+bunnyshell.com/dev v0.7.2 h1:fa0ZvnIAXLVJINCJqo7uenjHmjPrlHmY18Zc8ypo/6E=
+bunnyshell.com/dev v0.7.2/go.mod h1:+Xk46UXX9AW0nHrFMdO/IwpUPfALrck1/qI+LIXsDmE=
+bunnyshell.com/sdk v0.20.3 h1:Kd2s/fhkMrn6Jqp9UmnXfNu12Oiwg+hgNSNBOIBYPH8=
+bunnyshell.com/sdk v0.20.3/go.mod h1:RfgfUzZ4WHZGCkToUfu2/hoQS6XsQc8IdPTVAlpS138=
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=

--- a/pkg/api/environment/action_kubeconfig.go
+++ b/pkg/api/environment/action_kubeconfig.go
@@ -99,9 +99,10 @@ func KubeConfigRaw(options *common.ItemOptions) (*sdk.EnvironmentKubeConfigKubeC
 //
 // and an override string which can be one of:
 //
+//	"SCHEME://..."    → full replacement (any Scheme, host, port, path, etc.)
 //	":PORT"           → change only the port
 //	"HOST:PORT"       → change host and port
-//	"SCHEME://..."    → full replacement (any Scheme, host, port, path, etc.)
+//	"HOST"       	  → change only the host
 //
 // It returns the new URL string or an error.
 func overrideServer(base, override string) (string, error) {

--- a/pkg/api/environment/action_kubeconfig.go
+++ b/pkg/api/environment/action_kubeconfig.go
@@ -1,8 +1,13 @@
 package environment
 
 import (
+	"bytes"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"bunnyshell.com/cli/pkg/api"
 	"bunnyshell.com/cli/pkg/api/common"
@@ -20,11 +25,14 @@ type KubeConfigItem struct {
 
 type KubeConfigOptions struct {
 	common.ItemOptions
+
+	OverrideClusterServer string
 }
 
-func NewKubeConfigOptions(id string) *KubeConfigOptions {
+func NewKubeConfigOptions(id string, overrideClusterServer string) *KubeConfigOptions {
 	return &KubeConfigOptions{
-		ItemOptions: *common.NewItemOptions(id),
+		ItemOptions:           *common.NewItemOptions(id),
+		OverrideClusterServer: overrideClusterServer,
 	}
 }
 
@@ -34,14 +42,43 @@ func KubeConfig(options *KubeConfigOptions) (*KubeConfigItem, error) {
 		return nil, api.ParseError(resp, err)
 	}
 
-	bytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+	var cfgBytes []byte
+	if options.OverrideClusterServer != "" {
+		// normally it would be:
+		//     model.Clusters[0].Cluster.Server, err = overrideServer(model.Clusters[0].Cluster.Server, options.OverrideClusterServer)
+		//     if err != nil {
+		//			return nil, fmt.Errorf("error overriding cluster server: %w", err)
+		//		}
+		//     cfgBytes, err = yaml.Marshal(model)
+		//     if err != nil {
+		//         return nil, fmt.Errorf("error marshaling to YAML: %w", err)
+		//     }
+		// but model is not unmarshalled correctly, because the struct doesn't have yaml tags, only json tags,
+		// and the response is in application/x+yaml format (it skips the multi words properties like ApiVersion, CurrentContext)
+		// se we use the string replace hack
+
+		tmpBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		oldServer := model.Clusters[0].Cluster.Server
+		model.Clusters[0].Cluster.Server, err = overrideServer(model.Clusters[0].Cluster.Server, options.OverrideClusterServer)
+		if err != nil {
+			return nil, fmt.Errorf("error overriding cluster server: %w", err)
+		}
+
+		cfgBytes = bytes.ReplaceAll(tmpBytes, []byte(oldServer), []byte(model.Clusters[0].Cluster.Server))
+	} else {
+		cfgBytes, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &KubeConfigItem{
 		Data:  model,
-		Bytes: bytes,
+		Bytes: cfgBytes,
 	}, nil
 }
 
@@ -54,4 +91,60 @@ func KubeConfigRaw(options *common.ItemOptions) (*sdk.EnvironmentKubeConfigKubeC
 	request := lib.GetAPIFromProfile(profile).EnvironmentAPI.EnvironmentKubeConfig(ctx, options.ID)
 
 	return request.Execute()
+}
+
+// overrideServer takes a base Kubernetes server URL like
+//
+//	"https://my.example.com:6443"
+//
+// and an override string which can be one of:
+//
+//	":PORT"           → change only the port
+//	"HOST:PORT"       → change host and port
+//	"SCHEME://..."    → full replacement (any Scheme, host, port, path, etc.)
+//
+// It returns the new URL string or an error.
+func overrideServer(base, override string) (string, error) {
+	// Full-URL override
+	if strings.Contains(override, "://") {
+		// we treat anything containing "://" as a complete URL replacement
+		v, err := url.Parse(override)
+		if err != nil {
+			return "", fmt.Errorf("parsing full override %q: %w", override, err)
+		}
+		return v.String(), nil
+	}
+
+	// Parse the base
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parsing base %q: %w", base, err)
+	}
+
+	// Extract the existing host and port
+	host := u.Hostname()
+	port := u.Port()
+
+	switch {
+	case strings.HasPrefix(override, ":"):
+		// override only the port
+		port = strings.TrimPrefix(override, ":")
+
+	case strings.Contains(override, ":"):
+		// override both host and port
+		h, p, err := net.SplitHostPort(override)
+		if err != nil {
+			return "", fmt.Errorf("parsing host:port override %q: %w", override, err)
+		}
+		host, port = h, p
+
+	default:
+		// (optional) override only the host, keep existing port
+		host = override
+	}
+
+	// Re-join host and port (adds the brackets for IPv6 if needed)
+	u.Host = net.JoinHostPort(host, port)
+
+	return u.String(), nil
 }

--- a/pkg/api/template/validate.go
+++ b/pkg/api/template/validate.go
@@ -18,10 +18,13 @@ type ValidateOptions struct {
 	Organization string
 
 	WithComponents bool
+
+	AllowExtraFields bool
 }
 
 func (vo *ValidateOptions) UpdateFlagSet(flags *pflag.FlagSet) {
 	flags.BoolVar(&vo.WithComponents, "with-components", vo.WithComponents, "Validate components along with the template")
+	flags.BoolVar(&vo.AllowExtraFields, "allow-extra-fields", vo.AllowExtraFields, "Allow extra fields when validating components")
 }
 
 func NewValidateOptions() *ValidateOptions {
@@ -30,7 +33,8 @@ func NewValidateOptions() *ValidateOptions {
 
 		TemplateValidateAction: sdk.TemplateValidateAction{},
 
-		WithComponents: false,
+		WithComponents:   false,
+		AllowExtraFields: true,
 	}
 }
 

--- a/pkg/debug_component/action/action.go
+++ b/pkg/debug_component/action/action.go
@@ -23,8 +23,8 @@ func NewAction(
 	}
 }
 
-func (action *Action) GetDebugCmp(resource sdk.ComponentResourceItem) (*debug.DebugComponent, error) {
-	kubeConfigFile, err := action.workspace.DownloadKubeConfig()
+func (action *Action) GetDebugCmp(resource sdk.ComponentResourceItem, overrideClusterServer string) (*debug.DebugComponent, error) {
+	kubeConfigFile, err := action.workspace.DownloadKubeConfig(overrideClusterServer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/debug_component/action/down.go
+++ b/pkg/debug_component/action/down.go
@@ -6,6 +6,8 @@ import (
 
 type DownParameters struct {
 	Resource sdk.ComponentResourceItem
+
+	OverrideClusterServer string
 }
 
 type Down struct {
@@ -21,7 +23,7 @@ func NewDown(
 }
 
 func (down *Down) Run(parameters *DownParameters) error {
-	debugCmp, err := down.Action.GetDebugCmp(parameters.Resource)
+	debugCmp, err := down.Action.GetDebugCmp(parameters.Resource, parameters.OverrideClusterServer)
 	if err != nil {
 		return err
 	}

--- a/pkg/debug_component/action/down/down.cobra.go
+++ b/pkg/debug_component/action/down/down.cobra.go
@@ -10,4 +10,6 @@ func (down *Options) UpdateFlagSet(
 	flags *pflag.FlagSet,
 ) {
 	flags.StringVarP(&down.resourcePath, "resource", "s", down.resourcePath, "The cluster resource to use (namespace/kind/name format).")
+	flags.StringVar(&down.overrideClusterServer, "override-kubeconfig-cluster-server", down.overrideClusterServer, "Override kubeconfig cluster server with :port, host:port or scheme://host:port")
+
 }

--- a/pkg/debug_component/action/down/down.go
+++ b/pkg/debug_component/action/down/down.go
@@ -1,8 +1,8 @@
 package down
 
 import (
-	"bunnyshell.com/cli/pkg/k8s/bridge"
 	"bunnyshell.com/cli/pkg/debug_component/action"
+	"bunnyshell.com/cli/pkg/k8s/bridge"
 )
 
 type Options struct {
@@ -11,6 +11,8 @@ type Options struct {
 	resourceLoader *bridge.ResourceLoader
 
 	resourcePath string
+
+	overrideClusterServer string
 }
 
 func NewOptions(
@@ -18,6 +20,8 @@ func NewOptions(
 ) *Options {
 	return &Options{
 		resourceLoader: resourceLoader,
+
+		overrideClusterServer: "",
 	}
 }
 
@@ -29,7 +33,8 @@ func (down *Options) ToParameters() (*action.DownParameters, error) {
 	}
 
 	parameters := &action.DownParameters{
-		Resource: *down.resourceLoader.GetResource(),
+		Resource:              *down.resourceLoader.GetResource(),
+		OverrideClusterServer: down.overrideClusterServer,
 	}
 
 	return parameters, nil

--- a/pkg/debug_component/action/up.go
+++ b/pkg/debug_component/action/up.go
@@ -13,11 +13,11 @@ type UpOptions struct {
 
 	Command []string
 
-    LimitCPU    string
-    LimitMemory string
+	LimitCPU    string
+	LimitMemory string
 
-    RequestCPU    string
-    RequestMemory string
+	RequestCPU    string
+	RequestMemory string
 
 	WaitTimeout int64
 }
@@ -28,6 +28,8 @@ type UpParameters struct {
 	ManualSelectSingleResource bool
 
 	ForceRecreateResource bool
+
+	OverrideClusterServer string
 
 	Options *UpOptions
 }
@@ -55,7 +57,7 @@ func NewUp(
 }
 
 func (up *Up) Run(parameters *UpParameters) error {
-	debugCmp, err := up.Action.GetDebugCmp(parameters.Resource)
+	debugCmp, err := up.Action.GetDebugCmp(parameters.Resource, parameters.OverrideClusterServer)
 	if err != nil {
 		return err
 	}
@@ -93,9 +95,9 @@ func (up *Up) run(
 		return err
 	}
 
-    if err := debugCmp.CanUp(parameters.ForceRecreateResource); err != nil {
-        return err
-    }
+	if err := debugCmp.CanUp(parameters.ForceRecreateResource); err != nil {
+		return err
+	}
 
 	up.debugCmp = debugCmp
 
@@ -113,7 +115,7 @@ func (up *Up) loadDebugCmpOptions(debugCmp *debug.DebugComponent, options *UpOpt
 		debugCmp.WithWaitTimeout(options.WaitTimeout)
 	}
 
-    up.setContainerResources(&debugCmp.ContainerConfig, options)
+	up.setContainerResources(&debugCmp.ContainerConfig, options)
 
 	if len(options.EnvironPairs) > 0 {
 		for _, pair := range options.EnvironPairs {
@@ -139,17 +141,17 @@ func (up *Up) setContainerResources(containerConfig *container.Config, options *
 		}
 	}
 
-    if options.LimitCPU != "" {
-        if err := containerConfig.Resources.SetLimitsCPU(options.LimitCPU); err != nil {
-            return err
-        }
-    }
+	if options.LimitCPU != "" {
+		if err := containerConfig.Resources.SetLimitsCPU(options.LimitCPU); err != nil {
+			return err
+		}
+	}
 
-    if options.LimitMemory != "" {
-        if err := containerConfig.Resources.SetLimitsMemory(options.LimitMemory); err != nil {
-            return err
-        }
-    }
+	if options.LimitMemory != "" {
+		if err := containerConfig.Resources.SetLimitsMemory(options.LimitMemory); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/pkg/debug_component/action/up/up.cobra.go
+++ b/pkg/debug_component/action/up/up.cobra.go
@@ -19,13 +19,14 @@ func (up *Options) UpdateFlagSet(
 	_ = flags.MarkHidden("no-auto-select-one")
 
 	flags.BoolVar(
-        &up.ForceRecreateResource,
-        "force-recreate-resource",
-        up.ForceRecreateResource,
-        "Force recreate Pod even if another debug session is in progress. May break the debug down command",
-    )
+		&up.ForceRecreateResource,
+		"force-recreate-resource",
+		up.ForceRecreateResource,
+		"Force recreate Pod even if another debug session is in progress. May break the debug down command",
+	)
 
 	flags.DurationVarP(&up.waitTimeout, "wait-timeout", "w", up.waitTimeout, "Time to wait for the pod to be ready")
+	flags.StringVar(&up.overrideClusterServer, "override-kubeconfig-cluster-server", up.overrideClusterServer, "Override kubeconfig cluster server with :port, host:port or scheme://host:port")
 
 	flags.StringVarP(&up.resourcePath, "resource", "s", up.resourcePath, "The cluster resource to use (namespace/kind/name format).")
 	flags.StringVar(&up.containerName, "container", up.containerName, "The container name to use for remote development")

--- a/pkg/debug_component/action/up/up.cobra.go
+++ b/pkg/debug_component/action/up/up.cobra.go
@@ -22,14 +22,14 @@ func (up *Options) UpdateFlagSet(
 		&up.ForceRecreateResource,
 		"force-recreate-resource",
 		up.ForceRecreateResource,
-		"Force recreate Pod even if another debug session is in progress. May break the debug down command",
+		"Force recreate Pod even if another debug session is in progress. May break the debug stop command",
 	)
 
 	flags.DurationVarP(&up.waitTimeout, "wait-timeout", "w", up.waitTimeout, "Time to wait for the pod to be ready")
 	flags.StringVar(&up.overrideClusterServer, "override-kubeconfig-cluster-server", up.overrideClusterServer, "Override kubeconfig cluster server with :port, host:port or scheme://host:port")
 
 	flags.StringVarP(&up.resourcePath, "resource", "s", up.resourcePath, "The cluster resource to use (namespace/kind/name format).")
-	flags.StringVar(&up.containerName, "container", up.containerName, "The container name to use for remote development")
+	flags.StringVar(&up.containerName, "container", up.containerName, "The container name to use for debug session")
 
 	up.addContainerConfigFlags(flags)
 }

--- a/pkg/debug_component/action/up/up.go
+++ b/pkg/debug_component/action/up/up.go
@@ -3,8 +3,8 @@ package up
 import (
 	"time"
 
-	"bunnyshell.com/cli/pkg/k8s/bridge"
 	"bunnyshell.com/cli/pkg/debug_component/action"
+	"bunnyshell.com/cli/pkg/k8s/bridge"
 )
 
 type Options struct {
@@ -14,7 +14,8 @@ type Options struct {
 
 	resourceLoader *bridge.ResourceLoader
 
-	waitTimeout time.Duration
+	waitTimeout           time.Duration
+	overrideClusterServer string
 
 	resourcePath  string
 	containerName string
@@ -37,6 +38,8 @@ func NewOptions(
 		resourceLoader: resourceLoader,
 
 		waitTimeout: defaultWaitTimeout,
+
+		overrideClusterServer: "",
 	}
 }
 
@@ -53,7 +56,8 @@ func (up *Options) ToParameters() (*action.UpParameters, error) {
 
 	parameters := &action.UpParameters{
 		ManualSelectSingleResource: up.ManualSelectSingleResource,
-		ForceRecreateResource: up.ForceRecreateResource,
+		ForceRecreateResource:      up.ForceRecreateResource,
+		OverrideClusterServer:      up.overrideClusterServer,
 
 		Options: &action.UpOptions{
 			WaitTimeout: int64(up.waitTimeout.Seconds()),

--- a/pkg/formatter/stylish.go
+++ b/pkg/formatter/stylish.go
@@ -184,11 +184,11 @@ func tabulateBuildSettings(w *tabwriter.Writer, item *sdk.BuildSettingsItem) {
 }
 
 func tabulateEnvironmentCollection(w *tabwriter.Writer, data *sdk.PaginatedEnvironmentCollection) {
-	fmt.Fprintf(w, "%v\t %v\t %v\t %v\t %v\t %v\n", "EnvironmentID", "ProjectID", "Name", "Namespace", "Type", "OperationStatus")
+	fmt.Fprintf(w, "%v\t %v\t %v\t %v\t %v\t %v\t %v\n", "EnvironmentID", "ProjectID", "Name", "Namespace", "UrlHandle", "Type", "OperationStatus")
 
 	if data.Embedded != nil {
 		for _, item := range data.Embedded.Item {
-			fmt.Fprintf(w, "%v\t %v\t %v\t %v\t %v\t %v\n", item.GetId(), item.GetProject(), item.GetName(), item.GetNamespace(), item.GetType(), item.GetOperationStatus())
+			fmt.Fprintf(w, "%v\t %v\t %v\t %v\t %v\t %v\t %v\n", item.GetId(), item.GetProject(), item.GetName(), item.GetNamespace(), item.GetUrlHandle(), item.GetType(), item.GetOperationStatus())
 		}
 	}
 }
@@ -198,6 +198,7 @@ func tabulateEnvironmentItem(w *tabwriter.Writer, item *sdk.EnvironmentItem) {
 	fmt.Fprintf(w, "%v\t %v\n", "ProjectID", item.GetProject())
 	fmt.Fprintf(w, "%v\t %v\n", "Name", item.GetName())
 	fmt.Fprintf(w, "%v\t %v\n", "Namespace", item.GetNamespace())
+	fmt.Fprintf(w, "%v\t %v\n", "UrlHandle", item.GetUrlHandle())
 	fmt.Fprintf(w, "%v\t %v\n", "Type", item.GetType())
 	fmt.Fprintf(w, "%v\t %v\n", "Components", item.GetTotalComponents())
 	fmt.Fprintf(w, "%v\t %v\n", "OperationStatus", item.GetOperationStatus())

--- a/pkg/port_forward/workspace/vars.go
+++ b/pkg/port_forward/workspace/vars.go
@@ -1,0 +1,9 @@
+package workspace
+
+const (
+	workspacePerm = 0o700
+
+	kubeConfigPerm = 0o600
+
+	kubeConfigFilename = "kube-config.yaml"
+)

--- a/pkg/port_forward/workspace/workspace.go
+++ b/pkg/port_forward/workspace/workspace.go
@@ -1,0 +1,84 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+
+	"bunnyshell.com/cli/pkg/api/environment"
+	"bunnyshell.com/cli/pkg/util"
+)
+
+type Workspace struct {
+	environment string
+
+	rootDir string
+
+	kubeConfigFile string
+}
+
+func NewWorkspace(environment string) *Workspace {
+	return &Workspace{
+		environment: environment,
+	}
+}
+
+func (workspace *Workspace) GetEnvironmentDir() (string, error) {
+	if workspace.rootDir == "" {
+		dir, err := workspace.makeWorkspace()
+		if err != nil {
+			return "", err
+		}
+
+		workspace.rootDir = dir
+	}
+
+	return workspace.rootDir, nil
+}
+
+func (workspace *Workspace) GetKubeConfigFile() (string, error) {
+	if workspace.kubeConfigFile == "" {
+		envWorkspace, err := workspace.GetEnvironmentDir()
+		if err != nil {
+			return "", err
+		}
+
+		workspace.kubeConfigFile = filepath.Join(envWorkspace, kubeConfigFilename)
+	}
+
+	return workspace.kubeConfigFile, nil
+}
+
+func (workspace *Workspace) DownloadKubeConfig(overrideClusterServer string) (string, error) {
+	kubeConfigFile, err := workspace.GetKubeConfigFile()
+	if err != nil {
+		return "", err
+	}
+
+	kubeConfig, err := environment.KubeConfig(
+		environment.NewKubeConfigOptions(workspace.environment, overrideClusterServer),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	if err = os.WriteFile(kubeConfigFile, kubeConfig.Bytes, kubeConfigPerm); err != nil {
+		return "", err
+	}
+
+	return kubeConfigFile, nil
+}
+
+func (workspace *Workspace) makeWorkspace() (string, error) {
+	workspaceRoot, err := util.GetWorkspaceDir()
+	if err != nil {
+		return "", err
+	}
+
+	dir := filepath.Join(workspaceRoot, workspace.environment)
+
+	if err = os.MkdirAll(dir, workspacePerm); err != nil {
+		return "", err
+	}
+
+	return dir, nil
+}

--- a/pkg/remote_development/action/action.go
+++ b/pkg/remote_development/action/action.go
@@ -23,8 +23,8 @@ func NewAction(
 	}
 }
 
-func (action *Action) GetRemoteDev(resource sdk.ComponentResourceItem) (*remote.RemoteDevelopment, error) {
-	kubeConfigFile, err := action.workspace.DownloadKubeConfig()
+func (action *Action) GetRemoteDev(resource sdk.ComponentResourceItem, overrideClusterServer string) (*remote.RemoteDevelopment, error) {
+	kubeConfigFile, err := action.workspace.DownloadKubeConfig(overrideClusterServer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/remote_development/action/down.go
+++ b/pkg/remote_development/action/down.go
@@ -6,6 +6,8 @@ import (
 
 type DownParameters struct {
 	Resource sdk.ComponentResourceItem
+
+	OverrideClusterServer string
 }
 
 type Down struct {
@@ -21,7 +23,7 @@ func NewDown(
 }
 
 func (down *Down) Run(parameters *DownParameters) error {
-	remoteDev, err := down.Action.GetRemoteDev(parameters.Resource)
+	remoteDev, err := down.Action.GetRemoteDev(parameters.Resource, parameters.OverrideClusterServer)
 	if err != nil {
 		return err
 	}

--- a/pkg/remote_development/action/down/down.cobra.go
+++ b/pkg/remote_development/action/down/down.cobra.go
@@ -10,6 +10,7 @@ func (down *Options) UpdateFlagSet(
 	flags *pflag.FlagSet,
 ) {
 	flags.StringVarP(&down.resourcePath, "resource", "s", down.resourcePath, "The cluster resource to use (namespace/kind/name format).")
+	flags.StringVar(&down.overrideClusterServer, "override-kubeconfig-cluster-server", down.overrideClusterServer, "Override kubeconfig cluster server with :port, host:port or scheme://host:port")
 
 	down.manager.UpdateFlagSet(command, flags)
 }

--- a/pkg/remote_development/action/down/down.go
+++ b/pkg/remote_development/action/down/down.go
@@ -14,6 +14,8 @@ type Options struct {
 	resourceLoader *bridge.ResourceLoader
 
 	resourcePath string
+
+	overrideClusterServer string
 }
 
 func NewOptions(
@@ -24,6 +26,8 @@ func NewOptions(
 		manager: manager,
 
 		resourceLoader: resourceLoader,
+
+		overrideClusterServer: "",
 	}
 }
 
@@ -35,7 +39,8 @@ func (down *Options) ToParameters() (*action.DownParameters, error) {
 	}
 
 	parameters := &action.DownParameters{
-		Resource: *down.resourceLoader.GetResource(),
+		Resource:              *down.resourceLoader.GetResource(),
+		OverrideClusterServer: down.overrideClusterServer,
 	}
 
 	return parameters, nil

--- a/pkg/remote_development/action/up.go
+++ b/pkg/remote_development/action/up.go
@@ -29,6 +29,8 @@ type UpParameters struct {
 
 	PortMappings []string
 
+	ForceRecreateResource bool
+
 	OverrideClusterServer string
 
 	Options *UpOptions
@@ -127,7 +129,7 @@ func (up *Up) run(
 		return err
 	}
 
-	if err := remoteDev.CanUp(); err != nil {
+	if err := remoteDev.CanUp(parameters.ForceRecreateResource); err != nil {
 		return err
 	}
 

--- a/pkg/remote_development/action/up.go
+++ b/pkg/remote_development/action/up.go
@@ -29,6 +29,8 @@ type UpParameters struct {
 
 	PortMappings []string
 
+	OverrideClusterServer string
+
 	Options *UpOptions
 }
 
@@ -80,7 +82,7 @@ func NewUp(
 }
 
 func (up *Up) Run(parameters *UpParameters) error {
-	remoteDev, err := up.Action.GetRemoteDev(parameters.Resource)
+	remoteDev, err := up.Action.GetRemoteDev(parameters.Resource, parameters.OverrideClusterServer)
 	if err != nil {
 		return err
 	}
@@ -125,9 +127,9 @@ func (up *Up) run(
 		return err
 	}
 
-    if err := remoteDev.CanUp(); err != nil {
-        return err
-    }
+	if err := remoteDev.CanUp(); err != nil {
+		return err
+	}
 
 	if err := remoteDev.PrepareSSHTunnels(parameters.PortMappings); err != nil {
 		return err

--- a/pkg/remote_development/action/up/up.cobra.go
+++ b/pkg/remote_development/action/up/up.cobra.go
@@ -24,6 +24,7 @@ func (up *Options) UpdateFlagSet(
 	_ = flags.MarkHidden("no-auto-select-one")
 
 	flags.DurationVarP(&up.waitTimeout, "wait-timeout", "w", up.waitTimeout, "Time to wait for the pod to be ready")
+	flags.StringVar(&up.overrideClusterServer, "override-kubeconfig-cluster-server", up.overrideClusterServer, "Override kubeconfig cluster server with :port, host:port or scheme://host:port")
 
 	flags.StringVarP(
 		&up.localSyncPath,

--- a/pkg/remote_development/action/up/up.cobra.go
+++ b/pkg/remote_development/action/up/up.cobra.go
@@ -23,6 +23,13 @@ func (up *Options) UpdateFlagSet(
 
 	_ = flags.MarkHidden("no-auto-select-one")
 
+	flags.BoolVar(
+		&up.ForceRecreateResource,
+		"force-recreate-resource",
+		up.ForceRecreateResource,
+		"Force recreate Pod even if another remote-development session is in progress. May break the remote-development down command",
+	)
+
 	flags.DurationVarP(&up.waitTimeout, "wait-timeout", "w", up.waitTimeout, "Time to wait for the pod to be ready")
 	flags.StringVar(&up.overrideClusterServer, "override-kubeconfig-cluster-server", up.overrideClusterServer, "Override kubeconfig cluster server with :port, host:port or scheme://host:port")
 

--- a/pkg/remote_development/action/up/up.go
+++ b/pkg/remote_development/action/up/up.go
@@ -13,6 +13,8 @@ import (
 type Options struct {
 	ManualSelectSingleResource bool
 
+	ForceRecreateResource bool
+
 	manager *config.Manager
 
 	resourceLoader *bridge.ResourceLoader
@@ -79,6 +81,8 @@ func (up *Options) ToParameters() (*action.UpParameters, error) {
 		SyncMode: SyncModeToMutagenMode[up.syncMode],
 
 		ManualSelectSingleResource: up.ManualSelectSingleResource,
+
+		ForceRecreateResource: up.ForceRecreateResource,
 
 		PortMappings: up.portMappings,
 

--- a/pkg/remote_development/action/up/up.go
+++ b/pkg/remote_development/action/up/up.go
@@ -17,7 +17,8 @@ type Options struct {
 
 	resourceLoader *bridge.ResourceLoader
 
-	waitTimeout time.Duration
+	waitTimeout           time.Duration
+	overrideClusterServer string
 
 	resourcePath  string
 	containerName string
@@ -50,6 +51,8 @@ func NewOptions(
 		resourceLoader: resourceLoader,
 
 		waitTimeout: defaultWaitTimeout,
+
+		overrideClusterServer: "",
 
 		syncMode: TwoWayResolved,
 
@@ -160,6 +163,10 @@ func (up *Options) makeAbsolutePaths(parameters *action.UpParameters) error {
 }
 
 func (up *Options) fillFromFlags(parameters *action.UpParameters) {
+	if up.overrideClusterServer != "" {
+		parameters.OverrideClusterServer = up.overrideClusterServer
+	}
+
 	if up.localSyncPath != "" {
 		ensureProfileSyncPath(parameters).SetLocalPath(up.localSyncPath)
 	}

--- a/pkg/remote_development/workspace/workspace.go
+++ b/pkg/remote_development/workspace/workspace.go
@@ -48,14 +48,14 @@ func (workspace *Workspace) GetKubeConfigFile() (string, error) {
 	return workspace.kubeConfigFile, nil
 }
 
-func (workspace *Workspace) DownloadKubeConfig() (string, error) {
+func (workspace *Workspace) DownloadKubeConfig(overrideClusterServer string) (string, error) {
 	kubeConfigFile, err := workspace.GetKubeConfigFile()
 	if err != nil {
 		return "", err
 	}
 
 	kubeConfig, err := environment.KubeConfig(
-		environment.NewKubeConfigOptions(workspace.environment),
+		environment.NewKubeConfigOptions(workspace.environment, overrideClusterServer),
 	)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
- add overwrite-kubeconfig-cluster-server flag for kube related commands
- show urlHandle for environments
- add allow-extra-fields for template validation
- successive remote-dev up won't recreate Pod