### PR TITLE
Add pipeline logs and jobs commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,22 @@
+<!-- OPENSPEC:START -->
+# OpenSpec Instructions
+
+These instructions are for AI assistants working in this project.
+
+Always open `@/openspec/AGENTS.md` when the request:
+- Mentions planning or proposals (words like proposal, spec, change, plan)
+- Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
+- Sounds ambiguous and you need the authoritative spec before coding
+
+Use `@/openspec/AGENTS.md` to learn:
+- How to create and apply change proposals
+- Spec format and conventions
+- Project structure and guidelines
+
+Keep this managed block so 'openspec update' can refresh the instructions.
+
+<!-- OPENSPEC:END -->
+
 # Bunnyshell CLI (bns) - Developer Guide
 
 This document provides a comprehensive overview of the Bunnyshell CLI codebase to help developers and AI assistants understand the project structure, architecture, and development patterns.

--- a/cmd/pipeline/jobs.go
+++ b/cmd/pipeline/jobs.go
@@ -1,0 +1,110 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"bunnyshell.com/cli/pkg/api/workflow_job"
+	"bunnyshell.com/cli/pkg/config"
+	"bunnyshell.com/cli/pkg/util"
+	"bunnyshell.com/sdk"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	var pipelineID string
+	var outputFormat string
+
+	command := &cobra.Command{
+		Use: "jobs",
+
+		Short: "List jobs in a pipeline",
+		Long: `List all jobs within a pipeline, showing their ID, name, type, status, and duration.
+
+Use the job IDs from this output with 'bns pipeline logs --job JOB_ID' to view logs for a specific job.
+
+Examples:
+  # List jobs in a pipeline
+  bns pipeline jobs --id PIPELINE_ID
+
+  # JSON output
+  bns pipeline jobs --id PIPELINE_ID --output json`,
+
+		ValidArgsFunction: cobra.NoFileCompletions,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profile := config.GetSettings().Profile
+
+			spinner := util.MakeSpinner(" Fetching pipeline jobs...")
+			spinner.Start()
+
+			jobIDs, err := getWorkflowJobs(pipelineID, profile)
+			if err != nil {
+				spinner.Stop()
+				return fmt.Errorf("failed to get jobs for pipeline %s: %w", pipelineID, err)
+			}
+
+			var jobs []sdk.WorkflowJobItem
+			for _, jobID := range jobIDs {
+				info, err := workflow_job.GetJobInfo(profile, jobID)
+				if err != nil {
+					spinner.Stop()
+					return fmt.Errorf("failed to get info for job %s: %w", jobID, err)
+				}
+				jobs = append(jobs, *info)
+			}
+
+			spinner.Stop()
+
+			model := &workflow_job.WorkflowJobList{
+				PipelineID: pipelineID,
+				Jobs:       jobs,
+			}
+
+			return outputJobList(model, outputFormat)
+		},
+	}
+
+	flags := command.Flags()
+	flags.AddFlag(getIDOption(&pipelineID).GetRequiredFlag("id"))
+	flags.StringVarP(&outputFormat, "output", "o", "stylish", "Output format: stylish, json")
+
+	config.MainManager.CommandWithGlobalOptions(command)
+
+	mainCmd.AddCommand(command)
+}
+
+func outputJobList(data *workflow_job.WorkflowJobList, format string) error {
+	switch format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(data)
+	case "stylish":
+		writer := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
+
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", "JobID", "Name", "Type", "Status", "Duration")
+
+		for _, job := range data.Jobs {
+			duration := "-"
+			if job.HasDuration() {
+				duration = (time.Duration(job.GetDuration()) * time.Second).String()
+			}
+
+			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n",
+				job.GetId(),
+				job.GetName(),
+				job.GetType(),
+				job.GetStatus(),
+				duration,
+			)
+		}
+
+		return writer.Flush()
+	default:
+		return fmt.Errorf("unknown output format: %s (use: stylish, json)", format)
+	}
+}

--- a/cmd/pipeline/logs.go
+++ b/cmd/pipeline/logs.go
@@ -1,17 +1,15 @@
 package pipeline
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 
+	"bunnyshell.com/cli/pkg/api/workflow"
 	"bunnyshell.com/cli/pkg/api/workflow_job"
 	"bunnyshell.com/cli/pkg/config"
 	"bunnyshell.com/cli/pkg/formatter/pipeline_logs"
-	"bunnyshell.com/cli/pkg/lib"
 	"bunnyshell.com/cli/pkg/util"
+	"bunnyshell.com/sdk"
 	"github.com/spf13/cobra"
 )
 
@@ -19,51 +17,51 @@ func init() {
 	options := NewLogsOptions()
 
 	command := &cobra.Command{
-		Use:     "logs [ENVIRONMENT_ID]",
+		Use:     "logs",
 		Aliases: []string{"log"},
 
 		Short: "View pipeline logs for an environment",
 		Long: `View and stream logs from pipeline executions (build jobs, deployment steps).
 
-This command fetches logs from all workflow jobs and displays them in a structured format.
+This command fetches logs from all jobs and displays them in a structured format.
 Use --follow to stream logs in real-time for active pipelines.
 
 Examples:
   # View latest pipeline logs (all jobs)
-  bns pipeline logs my-env
+  bns pipeline logs --environment ENV_ID
 
   # View only failed jobs
-  bns pipeline logs my-env --failed
+  bns pipeline logs --environment ENV_ID --failed
 
-  # View a specific workflow (use 'bns pipeline list' to find IDs)
-  bns pipeline logs my-env --workflow WORKFLOW_ID
+  # View a specific pipeline (use 'bns pipeline list' to find IDs)
+  bns pipeline logs --id PIPELINE_ID
 
-  # View a specific job within a workflow
-  bns pipeline logs my-env --job JOB_ID
+  # View a specific job within a pipeline
+  bns pipeline logs --job JOB_ID
 
   # Follow active pipeline logs
-  bns pipeline logs my-env --follow
+  bns pipeline logs --environment ENV_ID --follow
 
   # View only specific step
-  bns pipeline logs my-env --step build
+  bns pipeline logs --environment ENV_ID --step build
 
   # Show last 50 lines
-  bns pipeline logs my-env --tail 50
+  bns pipeline logs --environment ENV_ID --tail 50
 
   # JSON output for parsing
-  bns pipeline logs my-env --output json`,
+  bns pipeline logs --environment ENV_ID --output json`,
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			// Get environment ID from args or context
-			if len(args) > 0 {
-				options.EnvironmentID = args[0]
-			} else if ctx := config.GetSettings().Profile.Context; ctx.Environment != "" {
-				options.EnvironmentID = ctx.Environment
+			// Fall back to context if --environment not provided
+			if options.EnvironmentID == "" {
+				if ctx := config.GetSettings().Profile.Context; ctx.Environment != "" {
+					options.EnvironmentID = ctx.Environment
+				}
 			}
 
-			// Environment ID not required when --job is specified directly
-			if options.EnvironmentID == "" && options.JobID == "" {
-				return fmt.Errorf("environment required: provide ID/name or set context with 'bns configure set-context --environment ID'")
+			// Environment ID not required when --job or --id is specified directly
+			if options.EnvironmentID == "" && options.JobID == "" && options.WorkflowID == "" {
+				return fmt.Errorf("environment required: provide --environment or set context with 'bns configure set-context --environment ID'")
 			}
 
 			return nil
@@ -75,12 +73,13 @@ Examples:
 	}
 
 	// Add flags
+	command.Flags().StringVar(&options.EnvironmentID, "environment", "", "Environment ID")
 	command.Flags().BoolVarP(&options.Follow, "follow", "f", false, "Follow log output (stream in real-time)")
 	command.Flags().BoolVar(&options.Failed, "failed", false, "Show only failed jobs")
 	command.Flags().IntVar(&options.Tail, "tail", 0, "Show last N lines")
 	command.Flags().StringVar(&options.Step, "step", "", "Filter logs by step name")
-	command.Flags().StringVar(&options.JobID, "job", "", "Specific workflow job ID (shows only that job)")
-	command.Flags().StringVar(&options.WorkflowID, "workflow", "", "Specific workflow ID (use 'bns pipeline list' to find IDs)")
+	command.Flags().StringVar(&options.JobID, "job", "", "Specific job ID (shows only that job)")
+	command.Flags().StringVar(&options.WorkflowID, "id", "", "Pipeline ID (use 'bns pipeline list' to find IDs)")
 	command.Flags().StringVarP(&options.OutputFormat, "output", "o", "stylish", "Output format: stylish, json, yaml, raw")
 
 	// Add global options
@@ -131,33 +130,33 @@ func runLogs(options *LogsOptions) error {
 	spinner := util.MakeSpinner(" Fetching pipeline info...")
 	spinner.Start()
 
-	var jobs []workflow_job.JobInfo
+	var jobs []*sdk.WorkflowJobItem
 	for _, jobID := range wfInfo.JobIDs {
 		info, err := workflow_job.GetJobInfo(options.Profile, jobID)
 		if err != nil {
 			spinner.Stop()
 			return fmt.Errorf("failed to get info for job %s: %w", jobID, err)
 		}
-		jobs = append(jobs, *info)
+		jobs = append(jobs, info)
 	}
 	spinner.Stop()
 
 	// Filter by --failed
 	if options.Failed {
-		var filtered []workflow_job.JobInfo
+		var filtered []*sdk.WorkflowJobItem
 		for _, job := range jobs {
-			if job.Status == "failed" {
+			if job.GetStatus() == "failed" {
 				filtered = append(filtered, job)
 			}
 		}
 		if len(filtered) == 0 {
-			fmt.Fprintln(os.Stderr, "No failed jobs in this workflow.")
+			fmt.Fprintln(os.Stderr, "No failed jobs in this pipeline.")
 			fmt.Fprintf(os.Stderr, "Jobs: ")
 			for i, job := range jobs {
 				if i > 0 {
 					fmt.Fprintf(os.Stderr, ", ")
 				}
-				fmt.Fprintf(os.Stderr, "%s [%s]", job.Name, job.Status)
+				fmt.Fprintf(os.Stderr, "%s [%s]", job.GetName(), job.GetStatus())
 			}
 			fmt.Fprintln(os.Stderr)
 			return nil
@@ -174,12 +173,12 @@ func runLogs(options *LogsOptions) error {
 	}
 
 	for _, job := range jobs {
-		logs, err := fetchJobLogs(options, job.ID)
+		logs, err := fetchJobLogs(options, job.GetId())
 		if err != nil {
 			spinner.Stop()
-			return fmt.Errorf("failed to fetch logs for job %s (%s): %w", job.ID, job.Name, err)
+			return fmt.Errorf("failed to fetch logs for job %s (%s): %w", job.GetId(), job.GetName(), err)
 		}
-		logs.JobName = job.Name
+		logs.JobName = job.GetName()
 
 		// Apply step filter per job
 		if options.Step != "" {
@@ -203,16 +202,16 @@ func runLogs(options *LogsOptions) error {
 func runSingleJobLogs(options *LogsOptions) error {
 	// Get job info for the name
 	info, err := workflow_job.GetJobInfo(options.Profile, options.JobID)
-	if err != nil {
-		// Non-fatal: we can still show logs without the name
-		info = &workflow_job.JobInfo{ID: options.JobID, Name: options.JobID}
+	jobName := options.JobID
+	if err == nil {
+		jobName = info.GetName()
 	}
 
 	logs, err := fetchJobLogs(options, options.JobID)
 	if err != nil {
 		return err
 	}
-	logs.JobName = info.Name
+	logs.JobName = jobName
 
 	if options.Step != "" {
 		logs = filterByStep(logs, options.Step)
@@ -235,7 +234,7 @@ func resolveWorkflow(options *LogsOptions) (*workflowInfo, error) {
 		// Use explicitly provided workflow ID
 		jobIDs, err := getWorkflowJobs(options.WorkflowID, options.Profile)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get jobs for workflow %s: %w", options.WorkflowID, err)
+			return nil, fmt.Errorf("failed to get jobs for pipeline %s: %w", options.WorkflowID, err)
 		}
 		return &workflowInfo{WorkflowID: options.WorkflowID, JobIDs: jobIDs}, nil
 	}
@@ -246,62 +245,19 @@ func resolveWorkflow(options *LogsOptions) (*workflowInfo, error) {
 
 // getLatestWorkflowForEnvironment finds the latest workflow and returns all its job IDs
 func getLatestWorkflowForEnvironment(environmentID string, profile config.Profile) (*workflowInfo, error) {
-	ctx, cancel := lib.GetContextFromProfile(profile)
-	defer cancel()
-
-	scheme := profile.Scheme
-	if scheme == "" {
-		scheme = "https"
-	}
-	baseURL := fmt.Sprintf("%s://%s", scheme, profile.Host)
-	apiURL := fmt.Sprintf("%s/v1/workflows?environment=%s&page=1", baseURL, environmentID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	collection, err := workflow.List(&workflow.ListOptions{
+		Environment: environmentID,
+		Profile:     profile,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to fetch pipelines: %w", err)
 	}
 
-	req.Header.Set("X-Auth-Token", profile.Token)
-	req.Header.Set("Accept", "application/hal+json")
-
-	if config.GetSettings().Debug {
-		fmt.Fprintf(os.Stderr, "GET %s\n", apiURL)
+	if collection.Embedded == nil || len(collection.Embedded.Item) == 0 {
+		return nil, fmt.Errorf("no pipelines found for environment %s", environmentID)
 	}
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch workflows (HTTP %d)", resp.StatusCode)
-	}
-
-	// Parse collection response (jobs not included in collection, only in item view)
-	var workflowsResp struct {
-		Embedded struct {
-			Items []struct {
-				ID string `json:"id"`
-			} `json:"item"`
-		} `json:"_embedded"`
-	}
-
-	if err := json.Unmarshal(body, &workflowsResp); err != nil {
-		return nil, fmt.Errorf("failed to parse workflows response: %w", err)
-	}
-
-	if len(workflowsResp.Embedded.Items) == 0 {
-		return nil, fmt.Errorf("no workflows found for environment %s", environmentID)
-	}
-
-	workflowID := workflowsResp.Embedded.Items[0].ID
+	workflowID := collection.Embedded.Item[0].GetId()
 	jobIDs, err := getWorkflowJobs(workflowID, profile)
 	if err != nil {
 		return nil, err
@@ -312,57 +268,17 @@ func getLatestWorkflowForEnvironment(environmentID string, profile config.Profil
 
 // getWorkflowJobs fetches a workflow by ID and returns its job IDs
 func getWorkflowJobs(workflowID string, profile config.Profile) ([]string, error) {
-	ctx, cancel := lib.GetContextFromProfile(profile)
-	defer cancel()
-
-	scheme := profile.Scheme
-	if scheme == "" {
-		scheme = "https"
-	}
-	baseURL := fmt.Sprintf("%s://%s", scheme, profile.Host)
-	workflowURL := fmt.Sprintf("%s/v1/workflows/%s", baseURL, workflowID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, workflowURL, nil)
+	wf, err := workflow.Get(profile, workflowID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create workflow request: %w", err)
-	}
-	req.Header.Set("X-Auth-Token", profile.Token)
-	req.Header.Set("Accept", "application/hal+json")
-
-	if config.GetSettings().Debug {
-		fmt.Fprintf(os.Stderr, "GET %s\n", workflowURL)
+		return nil, fmt.Errorf("failed to fetch pipeline: %w", err)
 	}
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch workflow: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read workflow response: %w", err)
+	jobs := wf.GetJobs()
+	if len(jobs) == 0 {
+		return nil, fmt.Errorf("pipeline %s has no jobs", workflowID)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch workflow %s (HTTP %d)", workflowID, resp.StatusCode)
-	}
-
-	var workflowResp struct {
-		ID   string   `json:"id"`
-		Jobs []string `json:"jobs"`
-	}
-
-	if err := json.Unmarshal(body, &workflowResp); err != nil {
-		return nil, fmt.Errorf("failed to parse workflow response: %w", err)
-	}
-
-	if len(workflowResp.Jobs) == 0 {
-		return nil, fmt.Errorf("workflow %s has no jobs", workflowID)
-	}
-
-	return workflowResp.Jobs, nil
+	return jobs, nil
 }
 
 // fetchJobLogs fetches all pages of logs for a single job

--- a/cmd/pipeline/logs.go
+++ b/cmd/pipeline/logs.go
@@ -1,0 +1,269 @@
+package pipeline
+
+import (
+	"fmt"
+	"os"
+
+	"bunnyshell.com/cli/pkg/api/environment"
+	"bunnyshell.com/cli/pkg/api/workflow_job"
+	"bunnyshell.com/cli/pkg/config"
+	"bunnyshell.com/cli/pkg/formatter/pipeline_logs"
+	"bunnyshell.com/cli/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	options := NewLogsOptions()
+
+	command := &cobra.Command{
+		Use:     "logs [ENVIRONMENT_ID]",
+		Aliases: []string{"log"},
+
+		Short: "View pipeline logs for an environment",
+		Long: `View and stream logs from pipeline executions (build jobs, deployment steps).
+
+This command fetches logs from workflow jobs and displays them in a structured format.
+Use --follow to stream logs in real-time for active pipelines.
+
+Examples:
+  # View latest pipeline logs
+  bns pipeline logs my-env
+
+  # Follow active pipeline logs
+  bns pipeline logs my-env --follow
+
+  # View only specific step
+  bns pipeline logs my-env --step build
+
+  # Show last 50 lines
+  bns pipeline logs my-env --tail 50
+
+  # JSON output for parsing
+  bns pipeline logs my-env --output json`,
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Get environment ID from args or context
+			if len(args) > 0 {
+				options.EnvironmentID = args[0]
+			} else if ctx := config.GetSettings().Profile.Context; ctx.Environment != "" {
+				options.EnvironmentID = ctx.Environment
+			}
+
+			if options.EnvironmentID == "" {
+				return fmt.Errorf("environment required: provide ID/name or set context with 'bns configure set-context --environment ID'")
+			}
+
+			return nil
+		},
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogs(options)
+		},
+	}
+
+	// Add flags
+	command.Flags().BoolVarP(&options.Follow, "follow", "f", false, "Follow log output (stream in real-time)")
+	command.Flags().IntVar(&options.Tail, "tail", 0, "Show last N lines")
+	command.Flags().StringVar(&options.Step, "step", "", "Filter logs by step name")
+	command.Flags().StringVar(&options.JobID, "job", "", "Specific workflow job ID (defaults to latest)")
+	command.Flags().StringVarP(&options.OutputFormat, "output", "o", "stylish", "Output format: stylish, json, yaml, raw")
+
+	// Add global options
+	config.MainManager.CommandWithGlobalOptions(command)
+
+	mainCmd.AddCommand(command)
+}
+
+type LogsOptions struct {
+	EnvironmentID string
+	JobID         string
+	Follow        bool
+	Tail          int
+	Step          string
+	OutputFormat  string
+
+	Profile config.Profile
+}
+
+func NewLogsOptions() *LogsOptions {
+	return &LogsOptions{
+		OutputFormat: "stylish",
+	}
+}
+
+func runLogs(options *LogsOptions) error {
+	options.Profile = config.GetSettings().Profile
+
+	// If no explicit job ID, find the latest workflow job for the environment
+	if options.JobID == "" {
+		jobID, err := getLatestWorkflowJobForEnvironment(options.EnvironmentID, options.Profile)
+		if err != nil {
+			return fmt.Errorf("failed to find workflow job: %w", err)
+		}
+		options.JobID = jobID
+	}
+
+	// Fetch logs
+	var logs *workflow_job.WorkflowJobLogs
+	var err error
+
+	if options.Follow {
+		// Follow mode: stream logs with polling
+		logs, err = followLogs(options)
+	} else {
+		// One-shot: fetch all logs
+		logs, err = fetchLogs(options)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// Apply filters
+	if options.Step != "" {
+		logs = filterByStep(logs, options.Step)
+	}
+
+	if options.Tail > 0 {
+		logs = tailLogs(logs, options.Tail)
+	}
+
+	// Format and output
+	return outputLogs(logs, options.OutputFormat)
+}
+
+// getLatestWorkflowJobForEnvironment finds the latest workflow job for an environment
+func getLatestWorkflowJobForEnvironment(environmentID string, profile config.Profile) (string, error) {
+	// Get environment to find its workflow
+	itemOptions := environment.NewItemOptions(environmentID)
+	itemOptions.Profile = &profile
+
+	env, err := environment.Get(itemOptions)
+	if err != nil {
+		return "", fmt.Errorf("environment not found: %w", err)
+	}
+
+	// In production, you'd query the workflow API to get the latest job
+	// For now, returning a placeholder
+	// TODO: Implement proper workflow job lookup via SDK
+	if env.GetId() == "" {
+		return "", fmt.Errorf("environment has no workflow jobs")
+	}
+
+	// Placeholder - in real implementation, fetch from workflow API
+	return "wj-placeholder", fmt.Errorf("workflow job lookup not fully implemented - use --job flag to specify job ID explicitly")
+}
+
+// fetchLogs fetches all pages of logs
+func fetchLogs(options *LogsOptions) (*workflow_job.WorkflowJobLogs, error) {
+	spinner := util.MakeSpinner(" Fetching pipeline logs...")
+	spinner.Start()
+	defer spinner.Stop()
+
+	logs, err := workflow_job.FetchAllPages(&workflow_job.LogsOptions{
+		Profile: options.Profile,
+		JobID:   options.JobID,
+		Offset:  0,
+		Limit:   1000,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return logs, nil
+}
+
+// followLogs streams logs with polling
+func followLogs(options *LogsOptions) (*workflow_job.WorkflowJobLogs, error) {
+	// TODO: Implement follow mode with polling
+	// For now, just fetch once
+	fmt.Fprintln(os.Stderr, "⚠ Follow mode not yet fully implemented, showing current logs...")
+	return fetchLogs(options)
+}
+
+// filterByStep filters logs to only show specific step
+func filterByStep(logs *workflow_job.WorkflowJobLogs, stepName string) *workflow_job.WorkflowJobLogs {
+	filtered := &workflow_job.WorkflowJobLogs{
+		WorkflowJobID: logs.WorkflowJobID,
+		Status:        logs.Status,
+		Steps:         []workflow_job.LogStep{},
+		Pagination:    logs.Pagination,
+	}
+
+	for _, step := range logs.Steps {
+		if step.Name == stepName {
+			filtered.Steps = append(filtered.Steps, step)
+			return filtered
+		}
+	}
+
+	// Step not found
+	fmt.Fprintf(os.Stderr, "⚠ Step '%s' not found. Available steps:\n", stepName)
+	for _, step := range logs.Steps {
+		fmt.Fprintf(os.Stderr, "  - %s\n", step.Name)
+	}
+
+	return filtered
+}
+
+// tailLogs limits output to last N lines
+func tailLogs(logs *workflow_job.WorkflowJobLogs, n int) *workflow_job.WorkflowJobLogs {
+	// Count total logs
+	totalLogs := 0
+	for _, step := range logs.Steps {
+		totalLogs += len(step.Logs)
+	}
+
+	if totalLogs <= n {
+		return logs // No need to tail
+	}
+
+	// Calculate how many to skip
+	toSkip := totalLogs - n
+
+	tailed := &workflow_job.WorkflowJobLogs{
+		WorkflowJobID: logs.WorkflowJobID,
+		Status:        logs.Status,
+		Steps:         []workflow_job.LogStep{},
+		Pagination:    logs.Pagination,
+	}
+
+	skipped := 0
+	for _, step := range logs.Steps {
+		if skipped+len(step.Logs) <= toSkip {
+			// Skip entire step
+			skipped += len(step.Logs)
+			continue
+		}
+
+		// Partial step
+		newStep := step
+		startIdx := toSkip - skipped
+		if startIdx < 0 {
+			startIdx = 0
+		}
+		newStep.Logs = step.Logs[startIdx:]
+		tailed.Steps = append(tailed.Steps, newStep)
+
+		skipped += len(step.Logs)
+	}
+
+	return tailed
+}
+
+// outputLogs formats and outputs logs based on format
+func outputLogs(logs *workflow_job.WorkflowJobLogs, format string) error {
+	switch format {
+	case "stylish":
+		return pipeline_logs.NewStylishFormatter().Format(logs, os.Stdout)
+	case "json":
+		return pipeline_logs.NewJSONFormatter().Format(logs, os.Stdout)
+	case "yaml":
+		return pipeline_logs.NewYAMLFormatter().Format(logs, os.Stdout)
+	case "raw":
+		return pipeline_logs.NewRawFormatter().Format(logs, os.Stdout)
+	default:
+		return fmt.Errorf("unknown output format: %s (use: stylish, json, yaml, raw)", format)
+	}
+}

--- a/cmd/pipeline/logs.go
+++ b/cmd/pipeline/logs.go
@@ -1,13 +1,16 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 
-	"bunnyshell.com/cli/pkg/api/environment"
 	"bunnyshell.com/cli/pkg/api/workflow_job"
 	"bunnyshell.com/cli/pkg/config"
 	"bunnyshell.com/cli/pkg/formatter/pipeline_logs"
+	"bunnyshell.com/cli/pkg/lib"
 	"bunnyshell.com/cli/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -134,24 +137,77 @@ func runLogs(options *LogsOptions) error {
 
 // getLatestWorkflowJobForEnvironment finds the latest workflow job for an environment
 func getLatestWorkflowJobForEnvironment(environmentID string, profile config.Profile) (string, error) {
-	// Get environment to find its workflow
-	itemOptions := environment.NewItemOptions(environmentID)
-	itemOptions.Profile = &profile
+	ctx, cancel := lib.GetContextFromProfile(profile)
+	defer cancel()
 
-	env, err := environment.Get(itemOptions)
+	// Build API URL to get workflows for environment
+	scheme := profile.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	baseURL := fmt.Sprintf("%s://%s", scheme, profile.Host)
+	apiURL := fmt.Sprintf("%s/v1/workflows?environment=%s&page=1", baseURL, environmentID)
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
-		return "", fmt.Errorf("environment not found: %w", err)
+		return "", fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// In production, you'd query the workflow API to get the latest job
-	// For now, returning a placeholder
-	// TODO: Implement proper workflow job lookup via SDK
-	if env.GetId() == "" {
-		return "", fmt.Errorf("environment has no workflow jobs")
+	req.Header.Set("X-Auth-Token", profile.Token)
+	req.Header.Set("Accept", "application/hal+json")
+
+	if config.GetSettings().Debug {
+		fmt.Fprintf(os.Stderr, "GET %s\n", apiURL)
 	}
 
-	// Placeholder - in real implementation, fetch from workflow API
-	return "wj-placeholder", fmt.Errorf("workflow job lookup not fully implemented - use --job flag to specify job ID explicitly")
+	// Execute request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to fetch workflows (HTTP %d)", resp.StatusCode)
+	}
+
+	// Parse response
+	var workflowsResp struct {
+		Embedded struct {
+			Items []struct {
+				ID   string   `json:"id"`
+				Jobs []string `json:"jobs"`
+			} `json:"item"`
+		} `json:"_embedded"`
+	}
+
+	if err := json.Unmarshal(body, &workflowsResp); err != nil {
+		return "", fmt.Errorf("failed to parse workflows response: %w", err)
+	}
+
+	// Get latest workflow (first in list, as they're ordered by date)
+	if len(workflowsResp.Embedded.Items) == 0 {
+		return "", fmt.Errorf("no workflows found for environment %s", environmentID)
+	}
+
+	latestWorkflow := workflowsResp.Embedded.Items[0]
+
+	// Get latest job from workflow (last job in array)
+	if len(latestWorkflow.Jobs) == 0 {
+		return "", fmt.Errorf("workflow %s has no jobs (backend may need deployment with getJobs() method)", latestWorkflow.ID)
+	}
+
+	latestJobID := latestWorkflow.Jobs[len(latestWorkflow.Jobs)-1]
+
+	return latestJobID, nil
 }
 
 // fetchLogs fetches all pages of logs

--- a/cmd/pipeline/logs.go
+++ b/cmd/pipeline/logs.go
@@ -179,12 +179,11 @@ func getLatestWorkflowJobForEnvironment(environmentID string, profile config.Pro
 		return "", fmt.Errorf("failed to fetch workflows (HTTP %d)", resp.StatusCode)
 	}
 
-	// Parse response
+	// Parse collection response (jobs not included in collection, only in item view)
 	var workflowsResp struct {
 		Embedded struct {
 			Items []struct {
-				ID   string   `json:"id"`
-				Jobs []string `json:"jobs"`
+				ID string `json:"id"`
 			} `json:"item"`
 		} `json:"_embedded"`
 	}
@@ -193,21 +192,55 @@ func getLatestWorkflowJobForEnvironment(environmentID string, profile config.Pro
 		return "", fmt.Errorf("failed to parse workflows response: %w", err)
 	}
 
-	// Get latest workflow (first in list, as they're ordered by date)
 	if len(workflowsResp.Embedded.Items) == 0 {
 		return "", fmt.Errorf("no workflows found for environment %s", environmentID)
 	}
 
-	latestWorkflow := workflowsResp.Embedded.Items[0]
+	// Fetch individual workflow to get its jobs
+	workflowID := workflowsResp.Embedded.Items[0].ID
+	workflowURL := fmt.Sprintf("%s/v1/workflows/%s", baseURL, workflowID)
 
-	// Get latest job from workflow (last job in array)
-	if len(latestWorkflow.Jobs) == 0 {
-		return "", fmt.Errorf("workflow %s has no jobs (backend may need deployment with getJobs() method)", latestWorkflow.ID)
+	wReq, err := http.NewRequestWithContext(ctx, http.MethodGet, workflowURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create workflow request: %w", err)
+	}
+	wReq.Header.Set("X-Auth-Token", profile.Token)
+	wReq.Header.Set("Accept", "application/hal+json")
+
+	if config.GetSettings().Debug {
+		fmt.Fprintf(os.Stderr, "GET %s\n", workflowURL)
 	}
 
-	latestJobID := latestWorkflow.Jobs[len(latestWorkflow.Jobs)-1]
+	wResp, err := client.Do(wReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch workflow: %w", err)
+	}
+	defer wResp.Body.Close()
 
-	return latestJobID, nil
+	wBody, err := io.ReadAll(wResp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read workflow response: %w", err)
+	}
+
+	if wResp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to fetch workflow %s (HTTP %d)", workflowID, wResp.StatusCode)
+	}
+
+	var workflowResp struct {
+		ID   string   `json:"id"`
+		Jobs []string `json:"jobs"`
+	}
+
+	if err := json.Unmarshal(wBody, &workflowResp); err != nil {
+		return "", fmt.Errorf("failed to parse workflow response: %w", err)
+	}
+
+	if len(workflowResp.Jobs) == 0 {
+		return "", fmt.Errorf("workflow %s has no jobs", workflowID)
+	}
+
+	// Return last job (most recent)
+	return workflowResp.Jobs[len(workflowResp.Jobs)-1], nil
 }
 
 // fetchLogs fetches all pages of logs

--- a/cmd/pipeline/logs.go
+++ b/cmd/pipeline/logs.go
@@ -25,12 +25,21 @@ func init() {
 		Short: "View pipeline logs for an environment",
 		Long: `View and stream logs from pipeline executions (build jobs, deployment steps).
 
-This command fetches logs from workflow jobs and displays them in a structured format.
+This command fetches logs from all workflow jobs and displays them in a structured format.
 Use --follow to stream logs in real-time for active pipelines.
 
 Examples:
-  # View latest pipeline logs
+  # View latest pipeline logs (all jobs)
   bns pipeline logs my-env
+
+  # View only failed jobs
+  bns pipeline logs my-env --failed
+
+  # View a specific workflow (use 'bns pipeline list' to find IDs)
+  bns pipeline logs my-env --workflow WORKFLOW_ID
+
+  # View a specific job within a workflow
+  bns pipeline logs my-env --job JOB_ID
 
   # Follow active pipeline logs
   bns pipeline logs my-env --follow
@@ -52,7 +61,8 @@ Examples:
 				options.EnvironmentID = ctx.Environment
 			}
 
-			if options.EnvironmentID == "" {
+			// Environment ID not required when --job is specified directly
+			if options.EnvironmentID == "" && options.JobID == "" {
 				return fmt.Errorf("environment required: provide ID/name or set context with 'bns configure set-context --environment ID'")
 			}
 
@@ -66,9 +76,11 @@ Examples:
 
 	// Add flags
 	command.Flags().BoolVarP(&options.Follow, "follow", "f", false, "Follow log output (stream in real-time)")
+	command.Flags().BoolVar(&options.Failed, "failed", false, "Show only failed jobs")
 	command.Flags().IntVar(&options.Tail, "tail", 0, "Show last N lines")
 	command.Flags().StringVar(&options.Step, "step", "", "Filter logs by step name")
-	command.Flags().StringVar(&options.JobID, "job", "", "Specific workflow job ID (defaults to latest)")
+	command.Flags().StringVar(&options.JobID, "job", "", "Specific workflow job ID (shows only that job)")
+	command.Flags().StringVar(&options.WorkflowID, "workflow", "", "Specific workflow ID (use 'bns pipeline list' to find IDs)")
 	command.Flags().StringVarP(&options.OutputFormat, "output", "o", "stylish", "Output format: stylish, json, yaml, raw")
 
 	// Add global options
@@ -79,8 +91,10 @@ Examples:
 
 type LogsOptions struct {
 	EnvironmentID string
+	WorkflowID    string
 	JobID         string
 	Follow        bool
+	Failed        bool
 	Tail          int
 	Step          string
 	OutputFormat  string
@@ -94,53 +108,147 @@ func NewLogsOptions() *LogsOptions {
 	}
 }
 
+type workflowInfo struct {
+	WorkflowID string
+	JobIDs     []string
+}
+
 func runLogs(options *LogsOptions) error {
 	options.Profile = config.GetSettings().Profile
 
-	// If no explicit job ID, find the latest workflow job for the environment
-	if options.JobID == "" {
-		jobID, err := getLatestWorkflowJobForEnvironment(options.EnvironmentID, options.Profile)
-		if err != nil {
-			return fmt.Errorf("failed to find workflow job: %w", err)
-		}
-		options.JobID = jobID
+	// If a specific job ID is given, fetch only that job's logs (legacy single-job mode)
+	if options.JobID != "" {
+		return runSingleJobLogs(options)
 	}
 
-	// Fetch logs
-	var logs *workflow_job.WorkflowJobLogs
-	var err error
-
-	if options.Follow {
-		// Follow mode: stream logs with polling
-		logs, err = followLogs(options)
-	} else {
-		// One-shot: fetch all logs
-		logs, err = fetchLogs(options)
-	}
-
+	// Resolve which workflow to use
+	wfInfo, err := resolveWorkflow(options)
 	if err != nil {
 		return err
 	}
 
-	// Apply filters
+	// Fetch job metadata for all jobs in the workflow
+	spinner := util.MakeSpinner(" Fetching pipeline info...")
+	spinner.Start()
+
+	var jobs []workflow_job.JobInfo
+	for _, jobID := range wfInfo.JobIDs {
+		info, err := workflow_job.GetJobInfo(options.Profile, jobID)
+		if err != nil {
+			spinner.Stop()
+			return fmt.Errorf("failed to get info for job %s: %w", jobID, err)
+		}
+		jobs = append(jobs, *info)
+	}
+	spinner.Stop()
+
+	// Filter by --failed
+	if options.Failed {
+		var filtered []workflow_job.JobInfo
+		for _, job := range jobs {
+			if job.Status == "failed" {
+				filtered = append(filtered, job)
+			}
+		}
+		if len(filtered) == 0 {
+			fmt.Fprintln(os.Stderr, "No failed jobs in this workflow.")
+			fmt.Fprintf(os.Stderr, "Jobs: ")
+			for i, job := range jobs {
+				if i > 0 {
+					fmt.Fprintf(os.Stderr, ", ")
+				}
+				fmt.Fprintf(os.Stderr, "%s [%s]", job.Name, job.Status)
+			}
+			fmt.Fprintln(os.Stderr)
+			return nil
+		}
+		jobs = filtered
+	}
+
+	// Fetch logs for each job
+	spinner = util.MakeSpinner(fmt.Sprintf(" Fetching logs for %d job(s)...", len(jobs)))
+	spinner.Start()
+
+	pipelineLogs := &workflow_job.PipelineLogs{
+		WorkflowID: wfInfo.WorkflowID,
+	}
+
+	for _, job := range jobs {
+		logs, err := fetchJobLogs(options, job.ID)
+		if err != nil {
+			spinner.Stop()
+			return fmt.Errorf("failed to fetch logs for job %s (%s): %w", job.ID, job.Name, err)
+		}
+		logs.JobName = job.Name
+
+		// Apply step filter per job
+		if options.Step != "" {
+			logs = filterByStep(logs, options.Step)
+		}
+
+		pipelineLogs.Jobs = append(pipelineLogs.Jobs, *logs)
+	}
+
+	spinner.Stop()
+
+	// Apply tail across all jobs
+	if options.Tail > 0 {
+		pipelineLogs = tailPipelineLogs(pipelineLogs, options.Tail)
+	}
+
+	return outputPipelineLogs(pipelineLogs, options.OutputFormat)
+}
+
+// runSingleJobLogs handles the --job flag (single job mode)
+func runSingleJobLogs(options *LogsOptions) error {
+	// Get job info for the name
+	info, err := workflow_job.GetJobInfo(options.Profile, options.JobID)
+	if err != nil {
+		// Non-fatal: we can still show logs without the name
+		info = &workflow_job.JobInfo{ID: options.JobID, Name: options.JobID}
+	}
+
+	logs, err := fetchJobLogs(options, options.JobID)
+	if err != nil {
+		return err
+	}
+	logs.JobName = info.Name
+
 	if options.Step != "" {
 		logs = filterByStep(logs, options.Step)
 	}
 
-	if options.Tail > 0 {
-		logs = tailLogs(logs, options.Tail)
+	pipelineLogs := &workflow_job.PipelineLogs{
+		Jobs: []workflow_job.WorkflowJobLogs{*logs},
 	}
 
-	// Format and output
-	return outputLogs(logs, options.OutputFormat)
+	if options.Tail > 0 {
+		pipelineLogs = tailPipelineLogs(pipelineLogs, options.Tail)
+	}
+
+	return outputPipelineLogs(pipelineLogs, options.OutputFormat)
 }
 
-// getLatestWorkflowJobForEnvironment finds the latest workflow job for an environment
-func getLatestWorkflowJobForEnvironment(environmentID string, profile config.Profile) (string, error) {
+// resolveWorkflow determines which workflow to use and returns all its job IDs
+func resolveWorkflow(options *LogsOptions) (*workflowInfo, error) {
+	if options.WorkflowID != "" {
+		// Use explicitly provided workflow ID
+		jobIDs, err := getWorkflowJobs(options.WorkflowID, options.Profile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get jobs for workflow %s: %w", options.WorkflowID, err)
+		}
+		return &workflowInfo{WorkflowID: options.WorkflowID, JobIDs: jobIDs}, nil
+	}
+
+	// Auto-detect: find latest workflow for environment
+	return getLatestWorkflowForEnvironment(options.EnvironmentID, options.Profile)
+}
+
+// getLatestWorkflowForEnvironment finds the latest workflow and returns all its job IDs
+func getLatestWorkflowForEnvironment(environmentID string, profile config.Profile) (*workflowInfo, error) {
 	ctx, cancel := lib.GetContextFromProfile(profile)
 	defer cancel()
 
-	// Build API URL to get workflows for environment
 	scheme := profile.Scheme
 	if scheme == "" {
 		scheme = "https"
@@ -148,10 +256,9 @@ func getLatestWorkflowJobForEnvironment(environmentID string, profile config.Pro
 	baseURL := fmt.Sprintf("%s://%s", scheme, profile.Host)
 	apiURL := fmt.Sprintf("%s/v1/workflows?environment=%s&page=1", baseURL, environmentID)
 
-	// Create HTTP request
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("X-Auth-Token", profile.Token)
@@ -161,22 +268,20 @@ func getLatestWorkflowJobForEnvironment(environmentID string, profile config.Pro
 		fmt.Fprintf(os.Stderr, "GET %s\n", apiURL)
 	}
 
-	// Execute request
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to execute request: %w", err)
+		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	// Read response
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response: %w", err)
+		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to fetch workflows (HTTP %d)", resp.StatusCode)
+		return nil, fmt.Errorf("failed to fetch workflows (HTTP %d)", resp.StatusCode)
 	}
 
 	// Parse collection response (jobs not included in collection, only in item view)
@@ -189,41 +294,59 @@ func getLatestWorkflowJobForEnvironment(environmentID string, profile config.Pro
 	}
 
 	if err := json.Unmarshal(body, &workflowsResp); err != nil {
-		return "", fmt.Errorf("failed to parse workflows response: %w", err)
+		return nil, fmt.Errorf("failed to parse workflows response: %w", err)
 	}
 
 	if len(workflowsResp.Embedded.Items) == 0 {
-		return "", fmt.Errorf("no workflows found for environment %s", environmentID)
+		return nil, fmt.Errorf("no workflows found for environment %s", environmentID)
 	}
 
-	// Fetch individual workflow to get its jobs
 	workflowID := workflowsResp.Embedded.Items[0].ID
+	jobIDs, err := getWorkflowJobs(workflowID, profile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workflowInfo{WorkflowID: workflowID, JobIDs: jobIDs}, nil
+}
+
+// getWorkflowJobs fetches a workflow by ID and returns its job IDs
+func getWorkflowJobs(workflowID string, profile config.Profile) ([]string, error) {
+	ctx, cancel := lib.GetContextFromProfile(profile)
+	defer cancel()
+
+	scheme := profile.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	baseURL := fmt.Sprintf("%s://%s", scheme, profile.Host)
 	workflowURL := fmt.Sprintf("%s/v1/workflows/%s", baseURL, workflowID)
 
-	wReq, err := http.NewRequestWithContext(ctx, http.MethodGet, workflowURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, workflowURL, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create workflow request: %w", err)
+		return nil, fmt.Errorf("failed to create workflow request: %w", err)
 	}
-	wReq.Header.Set("X-Auth-Token", profile.Token)
-	wReq.Header.Set("Accept", "application/hal+json")
+	req.Header.Set("X-Auth-Token", profile.Token)
+	req.Header.Set("Accept", "application/hal+json")
 
 	if config.GetSettings().Debug {
 		fmt.Fprintf(os.Stderr, "GET %s\n", workflowURL)
 	}
 
-	wResp, err := client.Do(wReq)
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch workflow: %w", err)
+		return nil, fmt.Errorf("failed to fetch workflow: %w", err)
 	}
-	defer wResp.Body.Close()
+	defer resp.Body.Close()
 
-	wBody, err := io.ReadAll(wResp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read workflow response: %w", err)
+		return nil, fmt.Errorf("failed to read workflow response: %w", err)
 	}
 
-	if wResp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to fetch workflow %s (HTTP %d)", workflowID, wResp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch workflow %s (HTTP %d)", workflowID, resp.StatusCode)
 	}
 
 	var workflowResp struct {
@@ -231,50 +354,36 @@ func getLatestWorkflowJobForEnvironment(environmentID string, profile config.Pro
 		Jobs []string `json:"jobs"`
 	}
 
-	if err := json.Unmarshal(wBody, &workflowResp); err != nil {
-		return "", fmt.Errorf("failed to parse workflow response: %w", err)
+	if err := json.Unmarshal(body, &workflowResp); err != nil {
+		return nil, fmt.Errorf("failed to parse workflow response: %w", err)
 	}
 
 	if len(workflowResp.Jobs) == 0 {
-		return "", fmt.Errorf("workflow %s has no jobs", workflowID)
+		return nil, fmt.Errorf("workflow %s has no jobs", workflowID)
 	}
 
-	// Return last job (most recent)
-	return workflowResp.Jobs[len(workflowResp.Jobs)-1], nil
+	return workflowResp.Jobs, nil
 }
 
-// fetchLogs fetches all pages of logs
-func fetchLogs(options *LogsOptions) (*workflow_job.WorkflowJobLogs, error) {
-	spinner := util.MakeSpinner(" Fetching pipeline logs...")
-	spinner.Start()
-	defer spinner.Stop()
+// fetchJobLogs fetches all pages of logs for a single job
+func fetchJobLogs(options *LogsOptions, jobID string) (*workflow_job.WorkflowJobLogs, error) {
+	if options.Follow {
+		fmt.Fprintln(os.Stderr, "Warning: Follow mode not yet fully implemented, showing current logs...")
+	}
 
-	logs, err := workflow_job.FetchAllPages(&workflow_job.LogsOptions{
+	return workflow_job.FetchAllPages(&workflow_job.LogsOptions{
 		Profile: options.Profile,
-		JobID:   options.JobID,
+		JobID:   jobID,
 		Offset:  0,
 		Limit:   1000,
 	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return logs, nil
-}
-
-// followLogs streams logs with polling
-func followLogs(options *LogsOptions) (*workflow_job.WorkflowJobLogs, error) {
-	// TODO: Implement follow mode with polling
-	// For now, just fetch once
-	fmt.Fprintln(os.Stderr, "⚠ Follow mode not yet fully implemented, showing current logs...")
-	return fetchLogs(options)
 }
 
 // filterByStep filters logs to only show specific step
 func filterByStep(logs *workflow_job.WorkflowJobLogs, stepName string) *workflow_job.WorkflowJobLogs {
 	filtered := &workflow_job.WorkflowJobLogs{
 		WorkflowJobID: logs.WorkflowJobID,
+		JobName:       logs.JobName,
 		Status:        logs.Status,
 		Steps:         []workflow_job.LogStep{},
 		Pagination:    logs.Pagination,
@@ -283,66 +392,67 @@ func filterByStep(logs *workflow_job.WorkflowJobLogs, stepName string) *workflow
 	for _, step := range logs.Steps {
 		if step.Name == stepName {
 			filtered.Steps = append(filtered.Steps, step)
-			return filtered
 		}
-	}
-
-	// Step not found
-	fmt.Fprintf(os.Stderr, "⚠ Step '%s' not found. Available steps:\n", stepName)
-	for _, step := range logs.Steps {
-		fmt.Fprintf(os.Stderr, "  - %s\n", step.Name)
 	}
 
 	return filtered
 }
 
-// tailLogs limits output to last N lines
-func tailLogs(logs *workflow_job.WorkflowJobLogs, n int) *workflow_job.WorkflowJobLogs {
-	// Count total logs
+// tailPipelineLogs limits output to last N lines across all jobs
+func tailPipelineLogs(pl *workflow_job.PipelineLogs, n int) *workflow_job.PipelineLogs {
+	// Count total logs across all jobs
 	totalLogs := 0
-	for _, step := range logs.Steps {
-		totalLogs += len(step.Logs)
+	for _, job := range pl.Jobs {
+		for _, step := range job.Steps {
+			totalLogs += len(step.Logs)
+		}
 	}
 
 	if totalLogs <= n {
-		return logs // No need to tail
+		return pl
 	}
 
-	// Calculate how many to skip
 	toSkip := totalLogs - n
 
-	tailed := &workflow_job.WorkflowJobLogs{
-		WorkflowJobID: logs.WorkflowJobID,
-		Status:        logs.Status,
-		Steps:         []workflow_job.LogStep{},
-		Pagination:    logs.Pagination,
+	result := &workflow_job.PipelineLogs{
+		WorkflowID: pl.WorkflowID,
 	}
 
 	skipped := 0
-	for _, step := range logs.Steps {
-		if skipped+len(step.Logs) <= toSkip {
-			// Skip entire step
+	for _, job := range pl.Jobs {
+		newJob := workflow_job.WorkflowJobLogs{
+			WorkflowJobID: job.WorkflowJobID,
+			JobName:       job.JobName,
+			Status:        job.Status,
+			Pagination:    job.Pagination,
+		}
+
+		for _, step := range job.Steps {
+			if skipped+len(step.Logs) <= toSkip {
+				skipped += len(step.Logs)
+				continue
+			}
+
+			newStep := step
+			startIdx := toSkip - skipped
+			if startIdx < 0 {
+				startIdx = 0
+			}
+			newStep.Logs = step.Logs[startIdx:]
+			newJob.Steps = append(newJob.Steps, newStep)
 			skipped += len(step.Logs)
-			continue
 		}
 
-		// Partial step
-		newStep := step
-		startIdx := toSkip - skipped
-		if startIdx < 0 {
-			startIdx = 0
+		if len(newJob.Steps) > 0 {
+			result.Jobs = append(result.Jobs, newJob)
 		}
-		newStep.Logs = step.Logs[startIdx:]
-		tailed.Steps = append(tailed.Steps, newStep)
-
-		skipped += len(step.Logs)
 	}
 
-	return tailed
+	return result
 }
 
-// outputLogs formats and outputs logs based on format
-func outputLogs(logs *workflow_job.WorkflowJobLogs, format string) error {
+// outputPipelineLogs formats and outputs pipeline logs
+func outputPipelineLogs(logs *workflow_job.PipelineLogs, format string) error {
 	switch format {
 	case "stylish":
 		return pipeline_logs.NewStylishFormatter().Format(logs, os.Stdout)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ toolchain go1.23.2
 
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 
+replace bunnyshell.com/sdk => ../neo-sdk-generator/go/sdk-local
+
 require (
 	bunnyshell.com/dev v0.7.2
 	bunnyshell.com/sdk v0.20.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 bunnyshell.com/dev v0.7.2 h1:fa0ZvnIAXLVJINCJqo7uenjHmjPrlHmY18Zc8ypo/6E=
 bunnyshell.com/dev v0.7.2/go.mod h1:+Xk46UXX9AW0nHrFMdO/IwpUPfALrck1/qI+LIXsDmE=
-bunnyshell.com/sdk v0.20.4 h1:Na2e4xKdtbnZZ/+ACpjzM7fvBFriJWC3bVgNFSmqcJs=
-bunnyshell.com/sdk v0.20.4/go.mod h1:RfgfUzZ4WHZGCkToUfu2/hoQS6XsQc8IdPTVAlpS138=
 github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=

--- a/pkg/api/workflow/item.go
+++ b/pkg/api/workflow/item.go
@@ -1,0 +1,27 @@
+package workflow
+
+import (
+	"net/http"
+
+	"bunnyshell.com/cli/pkg/api"
+	"bunnyshell.com/cli/pkg/config"
+	"bunnyshell.com/cli/pkg/lib"
+	"bunnyshell.com/sdk"
+)
+
+func Get(profile config.Profile, id string) (*sdk.WorkflowItem, error) {
+	model, resp, err := GetRaw(profile, id)
+	if err != nil {
+		return nil, api.ParseError(resp, err)
+	}
+	return model, nil
+}
+
+func GetRaw(profile config.Profile, id string) (*sdk.WorkflowItem, *http.Response, error) {
+	ctx, cancel := lib.GetContextFromProfile(profile)
+	defer cancel()
+
+	request := lib.GetAPIFromProfile(profile).WorkflowAPI.WorkflowView(ctx, id)
+
+	return request.Execute()
+}

--- a/pkg/api/workflow/list.go
+++ b/pkg/api/workflow/list.go
@@ -1,0 +1,45 @@
+package workflow
+
+import (
+	"net/http"
+
+	"bunnyshell.com/cli/pkg/api"
+	"bunnyshell.com/cli/pkg/lib"
+	"bunnyshell.com/cli/pkg/config"
+	"bunnyshell.com/sdk"
+)
+
+type ListOptions struct {
+	Environment  string
+	Organization string
+	Status       string
+
+	Profile config.Profile
+}
+
+func List(options *ListOptions) (*sdk.PaginatedWorkflowCollection, error) {
+	model, resp, err := ListRaw(options)
+	if err != nil {
+		return nil, api.ParseError(resp, err)
+	}
+	return model, nil
+}
+
+func ListRaw(options *ListOptions) (*sdk.PaginatedWorkflowCollection, *http.Response, error) {
+	ctx, cancel := lib.GetContextFromProfile(options.Profile)
+	defer cancel()
+
+	request := lib.GetAPIFromProfile(options.Profile).WorkflowAPI.WorkflowList(ctx)
+
+	if options.Environment != "" {
+		request = request.Environment(options.Environment)
+	}
+	if options.Organization != "" {
+		request = request.Organization(options.Organization)
+	}
+	if options.Status != "" {
+		request = request.Status(options.Status)
+	}
+
+	return request.Execute()
+}

--- a/pkg/api/workflow_job/logs.go
+++ b/pkg/api/workflow_job/logs.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 
 	"bunnyshell.com/cli/pkg/config"
 	"bunnyshell.com/cli/pkg/lib"
@@ -66,8 +67,12 @@ func GetLogs(options *LogsOptions) (*WorkflowJobLogs, error) {
 	}
 
 	// Add authorization header
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", options.Profile.Token))
+	req.Header.Set("X-Auth-Token", options.Profile.Token)
 	req.Header.Set("Accept", "application/json")
+
+	if config.GetSettings().Debug {
+		fmt.Fprintf(os.Stderr, "GET %s\n", apiURL)
+	}
 
 	// Execute request
 	client := &http.Client{}
@@ -99,8 +104,12 @@ func GetLogs(options *LogsOptions) (*WorkflowJobLogs, error) {
 
 // buildAPIURL constructs the full API URL with query parameters
 func buildAPIURL(profile config.Profile, jobID string, offset, limit int) string {
-	baseURL := fmt.Sprintf("%s://%s", profile.Scheme, profile.Host)
-	path := fmt.Sprintf("/api/v1/workflow-jobs/%s/logs", jobID)
+	scheme := profile.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	baseURL := fmt.Sprintf("%s://%s", scheme, profile.Host)
+	path := fmt.Sprintf("/v1/workflow_jobs/%s/logs", jobID)
 
 	// Build query parameters
 	params := url.Values{}

--- a/pkg/api/workflow_job/logs.go
+++ b/pkg/api/workflow_job/logs.go
@@ -1,15 +1,10 @@
 package workflow_job
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"os"
-
+	"bunnyshell.com/cli/pkg/api"
 	"bunnyshell.com/cli/pkg/config"
 	"bunnyshell.com/cli/pkg/lib"
+	"bunnyshell.com/sdk"
 )
 
 // PipelineLogs wraps logs from all jobs in a workflow
@@ -18,15 +13,13 @@ type PipelineLogs struct {
 	Jobs       []WorkflowJobLogs `json:"jobs"`
 }
 
-// JobInfo contains metadata about a workflow job
-type JobInfo struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	Type   string `json:"type"`
-	Status string `json:"status"`
+// WorkflowJobList wraps a list of jobs for a pipeline
+type WorkflowJobList struct {
+	PipelineID string             `json:"pipelineId"`
+	Jobs       []sdk.WorkflowJobItem `json:"jobs"`
 }
 
-// WorkflowJobLogs represents the structure of workflow job logs API response
+// WorkflowJobLogs represents the structure of workflow job logs
 type WorkflowJobLogs struct {
 	WorkflowJobID string     `json:"workflowJobId"`
 	JobName       string     `json:"jobName,omitempty"`
@@ -66,100 +59,34 @@ type LogsOptions struct {
 	Limit   int
 }
 
-// GetLogs fetches workflow job logs from the API
+// GetJobInfo fetches metadata for a workflow job via the SDK
+func GetJobInfo(profile config.Profile, jobID string) (*sdk.WorkflowJobItem, error) {
+	ctx, cancel := lib.GetContextFromProfile(profile)
+	defer cancel()
+
+	model, resp, err := lib.GetAPIFromProfile(profile).WorkflowJobAPI.WorkflowJobView(ctx, jobID).Execute()
+	if err != nil {
+		return nil, api.ParseError(resp, err)
+	}
+
+	return model, nil
+}
+
+// GetLogs fetches workflow job logs from the API via the SDK
 func GetLogs(options *LogsOptions) (*WorkflowJobLogs, error) {
 	ctx, cancel := lib.GetContextFromProfile(options.Profile)
 	defer cancel()
 
-	// Build API URL
-	apiURL := buildAPIURL(options.Profile, options.JobID, options.Offset, options.Limit)
+	request := lib.GetAPIFromProfile(options.Profile).WorkflowJobAPI.WorkflowJobLogsList(ctx, options.JobID)
+	request = request.Offset(int32(options.Offset))
+	request = request.Limit(int32(options.Limit))
 
-	// Create HTTP request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	sdkLogs, resp, err := request.Execute()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, api.ParseError(resp, err)
 	}
 
-	// Add authorization header
-	req.Header.Set("X-Auth-Token", options.Profile.Token)
-	req.Header.Set("Accept", "application/hal+json")
-
-	if config.GetSettings().Debug {
-		fmt.Fprintf(os.Stderr, "GET %s\n", apiURL)
-	}
-
-	// Execute request
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Read response body
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	// Check for HTTP errors
-	if resp.StatusCode != http.StatusOK {
-		return nil, parseHTTPError(resp.StatusCode, body)
-	}
-
-	// Parse JSON response
-	var logs WorkflowJobLogs
-	if err := json.Unmarshal(body, &logs); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	return &logs, nil
-}
-
-// buildAPIURL constructs the full API URL with query parameters
-func buildAPIURL(profile config.Profile, jobID string, offset, limit int) string {
-	scheme := profile.Scheme
-	if scheme == "" {
-		scheme = "https"
-	}
-	baseURL := fmt.Sprintf("%s://%s", scheme, profile.Host)
-	path := fmt.Sprintf("/v1/workflow_jobs/%s/logs", jobID)
-
-	// Build query parameters
-	params := url.Values{}
-	params.Add("offset", fmt.Sprintf("%d", offset))
-	params.Add("limit", fmt.Sprintf("%d", limit))
-
-	return fmt.Sprintf("%s%s?%s", baseURL, path, params.Encode())
-}
-
-// parseHTTPError creates a user-friendly error message from HTTP response
-func parseHTTPError(statusCode int, body []byte) error {
-	var errorResp struct {
-		Error string `json:"error"`
-		Code  string `json:"code"`
-	}
-
-	// Try to parse error response
-	if err := json.Unmarshal(body, &errorResp); err == nil && errorResp.Error != "" {
-		return fmt.Errorf("%s (HTTP %d)", errorResp.Error, statusCode)
-	}
-
-	// Fallback to generic error messages
-	switch statusCode {
-	case http.StatusNotFound:
-		return fmt.Errorf("workflow job not found (HTTP 404)")
-	case http.StatusUnauthorized:
-		return fmt.Errorf("authentication failed. Run 'bns configure' to set your token (HTTP 401)")
-	case http.StatusForbidden:
-		return fmt.Errorf("access forbidden. You don't have permission to view these logs (HTTP 403)")
-	case http.StatusTooManyRequests:
-		return fmt.Errorf("rate limit exceeded. Please wait and try again (HTTP 429)")
-	case http.StatusBadGateway:
-		return fmt.Errorf("unable to retrieve log file from storage. Please try again later (HTTP 502)")
-	default:
-		return fmt.Errorf("API error (HTTP %d): %s", statusCode, string(body))
-	}
+	return fromSDKLogs(sdkLogs), nil
 }
 
 // FetchAllPages fetches all pages of logs automatically
@@ -171,38 +98,30 @@ func FetchAllPages(options *LogsOptions) (*WorkflowJobLogs, error) {
 	limit := options.Limit
 
 	for {
-		// Fetch current page
-		opts := &LogsOptions{
+		logs, err := GetLogs(&LogsOptions{
 			Profile: options.Profile,
 			JobID:   options.JobID,
 			Offset:  offset,
 			Limit:   limit,
-		}
-
-		logs, err := GetLogs(opts)
+		})
 		if err != nil {
 			return nil, err
 		}
 
-		// Store first page metadata
 		if allLogs == nil {
 			allLogs = logs
 			allSteps = logs.Steps
 		} else {
-			// Merge steps from subsequent pages
 			allSteps = mergeSteps(allSteps, logs.Steps)
 		}
 
-		// Check if more pages exist
 		if !logs.Pagination.HasMore {
 			break
 		}
 
-		// Move to next page
 		offset += limit
 	}
 
-	// Update final result
 	if allLogs != nil {
 		allLogs.Steps = allSteps
 		allLogs.Pagination.HasMore = false
@@ -211,69 +130,49 @@ func FetchAllPages(options *LogsOptions) (*WorkflowJobLogs, error) {
 	return allLogs, nil
 }
 
-// GetJobInfo fetches metadata (name, type, status) for a workflow job
-func GetJobInfo(profile config.Profile, jobID string) (*JobInfo, error) {
-	ctx, cancel := lib.GetContextFromProfile(profile)
-	defer cancel()
-
-	scheme := profile.Scheme
-	if scheme == "" {
-		scheme = "https"
-	}
-	apiURL := fmt.Sprintf("%s://%s/v1/workflow_jobs/%s", scheme, profile.Host, jobID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+// fromSDKLogs converts SDK response to CLI types
+func fromSDKLogs(sdkLogs *sdk.WorkflowJobLogsResponse) *WorkflowJobLogs {
+	logs := &WorkflowJobLogs{
+		WorkflowJobID: sdkLogs.WorkflowJobID,
+		Status:        sdkLogs.Status,
+		Pagination: Pagination{
+			Offset:  sdkLogs.Pagination.Offset,
+			Limit:   sdkLogs.Pagination.Limit,
+			Total:   sdkLogs.Pagination.Total,
+			HasMore: sdkLogs.Pagination.HasMore,
+		},
 	}
 
-	req.Header.Set("X-Auth-Token", profile.Token)
-	req.Header.Set("Accept", "application/hal+json")
-
-	if config.GetSettings().Debug {
-		fmt.Fprintf(os.Stderr, "GET %s\n", apiURL)
+	for _, sdkStep := range sdkLogs.Steps {
+		step := LogStep{
+			Name:      sdkStep.Name,
+			Status:    sdkStep.Status,
+			ExitCode:  sdkStep.ExitCode,
+			StartedAt: sdkStep.StartedAt,
+		}
+		for _, sdkLog := range sdkStep.Logs {
+			step.Logs = append(step.Logs, LogMessage{
+				Timestamp: sdkLog.Timestamp,
+				Message:   sdkLog.Message,
+			})
+		}
+		logs.Steps = append(logs.Steps, step)
 	}
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch job info: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read job info response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, parseHTTPError(resp.StatusCode, body)
-	}
-
-	var info JobInfo
-	if err := json.Unmarshal(body, &info); err != nil {
-		return nil, fmt.Errorf("failed to parse job info: %w", err)
-	}
-
-	return &info, nil
+	return logs
 }
 
 // mergeSteps merges log steps, combining logs from the same step
 func mergeSteps(existing, new []LogStep) []LogStep {
-	// If last existing step matches first new step, merge their logs
 	if len(existing) > 0 && len(new) > 0 {
 		lastExisting := &existing[len(existing)-1]
 		firstNew := new[0]
 
 		if lastExisting.Name == firstNew.Name {
-			// Merge logs
 			lastExisting.Logs = append(lastExisting.Logs, firstNew.Logs...)
-
-			// Append remaining new steps
 			return append(existing, new[1:]...)
 		}
 	}
 
-	// No overlap, just append
 	return append(existing, new...)
 }

--- a/pkg/api/workflow_job/logs.go
+++ b/pkg/api/workflow_job/logs.go
@@ -12,9 +12,24 @@ import (
 	"bunnyshell.com/cli/pkg/lib"
 )
 
+// PipelineLogs wraps logs from all jobs in a workflow
+type PipelineLogs struct {
+	WorkflowID string            `json:"workflowId"`
+	Jobs       []WorkflowJobLogs `json:"jobs"`
+}
+
+// JobInfo contains metadata about a workflow job
+type JobInfo struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}
+
 // WorkflowJobLogs represents the structure of workflow job logs API response
 type WorkflowJobLogs struct {
 	WorkflowJobID string     `json:"workflowJobId"`
+	JobName       string     `json:"jobName,omitempty"`
 	Status        string     `json:"status"`
 	Steps         []LogStep  `json:"steps"`
 	Pagination    Pagination `json:"pagination"`
@@ -194,6 +209,53 @@ func FetchAllPages(options *LogsOptions) (*WorkflowJobLogs, error) {
 	}
 
 	return allLogs, nil
+}
+
+// GetJobInfo fetches metadata (name, type, status) for a workflow job
+func GetJobInfo(profile config.Profile, jobID string) (*JobInfo, error) {
+	ctx, cancel := lib.GetContextFromProfile(profile)
+	defer cancel()
+
+	scheme := profile.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	apiURL := fmt.Sprintf("%s://%s/v1/workflow_jobs/%s", scheme, profile.Host, jobID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("X-Auth-Token", profile.Token)
+	req.Header.Set("Accept", "application/hal+json")
+
+	if config.GetSettings().Debug {
+		fmt.Fprintf(os.Stderr, "GET %s\n", apiURL)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch job info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read job info response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseHTTPError(resp.StatusCode, body)
+	}
+
+	var info JobInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("failed to parse job info: %w", err)
+	}
+
+	return &info, nil
 }
 
 // mergeSteps merges log steps, combining logs from the same step

--- a/pkg/api/workflow_job/logs.go
+++ b/pkg/api/workflow_job/logs.go
@@ -22,17 +22,16 @@ type WorkflowJobLogs struct {
 
 // LogStep represents a single step in the workflow
 type LogStep struct {
-	Name       string       `json:"name"`
-	Status     string       `json:"status"`
-	StartedAt  string       `json:"startedAt"`
-	FinishedAt string       `json:"finishedAt"`
-	Logs       []LogMessage `json:"logs"`
+	Name      string       `json:"name"`
+	Status    string       `json:"status"`
+	ExitCode  int          `json:"exitCode"`
+	StartedAt string       `json:"startedAt"`
+	Logs      []LogMessage `json:"logs"`
 }
 
 // LogMessage represents a single log message
 type LogMessage struct {
 	Timestamp string `json:"timestamp"`
-	Level     string `json:"level"`
 	Message   string `json:"message"`
 }
 
@@ -68,7 +67,7 @@ func GetLogs(options *LogsOptions) (*WorkflowJobLogs, error) {
 
 	// Add authorization header
 	req.Header.Set("X-Auth-Token", options.Profile.Token)
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", "application/hal+json")
 
 	if config.GetSettings().Debug {
 		fmt.Fprintf(os.Stderr, "GET %s\n", apiURL)
@@ -207,7 +206,6 @@ func mergeSteps(existing, new []LogStep) []LogStep {
 		if lastExisting.Name == firstNew.Name {
 			// Merge logs
 			lastExisting.Logs = append(lastExisting.Logs, firstNew.Logs...)
-			lastExisting.FinishedAt = firstNew.FinishedAt
 
 			// Append remaining new steps
 			return append(existing, new[1:]...)

--- a/pkg/api/workflow_job/logs.go
+++ b/pkg/api/workflow_job/logs.go
@@ -1,0 +1,210 @@
+package workflow_job
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"bunnyshell.com/cli/pkg/config"
+	"bunnyshell.com/cli/pkg/lib"
+)
+
+// WorkflowJobLogs represents the structure of workflow job logs API response
+type WorkflowJobLogs struct {
+	WorkflowJobID string     `json:"workflowJobId"`
+	Status        string     `json:"status"`
+	Steps         []LogStep  `json:"steps"`
+	Pagination    Pagination `json:"pagination"`
+}
+
+// LogStep represents a single step in the workflow
+type LogStep struct {
+	Name       string       `json:"name"`
+	Status     string       `json:"status"`
+	StartedAt  string       `json:"startedAt"`
+	FinishedAt string       `json:"finishedAt"`
+	Logs       []LogMessage `json:"logs"`
+}
+
+// LogMessage represents a single log message
+type LogMessage struct {
+	Timestamp string `json:"timestamp"`
+	Level     string `json:"level"`
+	Message   string `json:"message"`
+}
+
+// Pagination contains pagination metadata
+type Pagination struct {
+	Offset  int  `json:"offset"`
+	Limit   int  `json:"limit"`
+	Total   int  `json:"total"`
+	HasMore bool `json:"hasMore"`
+}
+
+// LogsOptions contains options for fetching workflow job logs
+type LogsOptions struct {
+	Profile config.Profile
+	JobID   string
+	Offset  int
+	Limit   int
+}
+
+// GetLogs fetches workflow job logs from the API
+func GetLogs(options *LogsOptions) (*WorkflowJobLogs, error) {
+	ctx, cancel := lib.GetContextFromProfile(options.Profile)
+	defer cancel()
+
+	// Build API URL
+	apiURL := buildAPIURL(options.Profile, options.JobID, options.Offset, options.Limit)
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Add authorization header
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", options.Profile.Token))
+	req.Header.Set("Accept", "application/json")
+
+	// Execute request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for HTTP errors
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseHTTPError(resp.StatusCode, body)
+	}
+
+	// Parse JSON response
+	var logs WorkflowJobLogs
+	if err := json.Unmarshal(body, &logs); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &logs, nil
+}
+
+// buildAPIURL constructs the full API URL with query parameters
+func buildAPIURL(profile config.Profile, jobID string, offset, limit int) string {
+	baseURL := fmt.Sprintf("%s://%s", profile.Scheme, profile.Host)
+	path := fmt.Sprintf("/api/v1/workflow-jobs/%s/logs", jobID)
+
+	// Build query parameters
+	params := url.Values{}
+	params.Add("offset", fmt.Sprintf("%d", offset))
+	params.Add("limit", fmt.Sprintf("%d", limit))
+
+	return fmt.Sprintf("%s%s?%s", baseURL, path, params.Encode())
+}
+
+// parseHTTPError creates a user-friendly error message from HTTP response
+func parseHTTPError(statusCode int, body []byte) error {
+	var errorResp struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+
+	// Try to parse error response
+	if err := json.Unmarshal(body, &errorResp); err == nil && errorResp.Error != "" {
+		return fmt.Errorf("%s (HTTP %d)", errorResp.Error, statusCode)
+	}
+
+	// Fallback to generic error messages
+	switch statusCode {
+	case http.StatusNotFound:
+		return fmt.Errorf("workflow job not found (HTTP 404)")
+	case http.StatusUnauthorized:
+		return fmt.Errorf("authentication failed. Run 'bns configure' to set your token (HTTP 401)")
+	case http.StatusForbidden:
+		return fmt.Errorf("access forbidden. You don't have permission to view these logs (HTTP 403)")
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("rate limit exceeded. Please wait and try again (HTTP 429)")
+	case http.StatusBadGateway:
+		return fmt.Errorf("unable to retrieve log file from storage. Please try again later (HTTP 502)")
+	default:
+		return fmt.Errorf("API error (HTTP %d): %s", statusCode, string(body))
+	}
+}
+
+// FetchAllPages fetches all pages of logs automatically
+func FetchAllPages(options *LogsOptions) (*WorkflowJobLogs, error) {
+	var allLogs *WorkflowJobLogs
+	var allSteps []LogStep
+
+	offset := options.Offset
+	limit := options.Limit
+
+	for {
+		// Fetch current page
+		opts := &LogsOptions{
+			Profile: options.Profile,
+			JobID:   options.JobID,
+			Offset:  offset,
+			Limit:   limit,
+		}
+
+		logs, err := GetLogs(opts)
+		if err != nil {
+			return nil, err
+		}
+
+		// Store first page metadata
+		if allLogs == nil {
+			allLogs = logs
+			allSteps = logs.Steps
+		} else {
+			// Merge steps from subsequent pages
+			allSteps = mergeSteps(allSteps, logs.Steps)
+		}
+
+		// Check if more pages exist
+		if !logs.Pagination.HasMore {
+			break
+		}
+
+		// Move to next page
+		offset += limit
+	}
+
+	// Update final result
+	if allLogs != nil {
+		allLogs.Steps = allSteps
+		allLogs.Pagination.HasMore = false
+	}
+
+	return allLogs, nil
+}
+
+// mergeSteps merges log steps, combining logs from the same step
+func mergeSteps(existing, new []LogStep) []LogStep {
+	// If last existing step matches first new step, merge their logs
+	if len(existing) > 0 && len(new) > 0 {
+		lastExisting := &existing[len(existing)-1]
+		firstNew := new[0]
+
+		if lastExisting.Name == firstNew.Name {
+			// Merge logs
+			lastExisting.Logs = append(lastExisting.Logs, firstNew.Logs...)
+			lastExisting.FinishedAt = firstNew.FinishedAt
+
+			// Append remaining new steps
+			return append(existing, new[1:]...)
+		}
+	}
+
+	// No overlap, just append
+	return append(existing, new...)
+}

--- a/pkg/formatter/pipeline_logs/json.go
+++ b/pkg/formatter/pipeline_logs/json.go
@@ -15,8 +15,8 @@ func NewJSONFormatter() *JSONFormatter {
 	return &JSONFormatter{}
 }
 
-// Format outputs logs in JSON format
-func (f *JSONFormatter) Format(logs *workflow_job.WorkflowJobLogs, w io.Writer) error {
+// Format outputs pipeline logs in JSON format
+func (f *JSONFormatter) Format(logs *workflow_job.PipelineLogs, w io.Writer) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(logs)

--- a/pkg/formatter/pipeline_logs/json.go
+++ b/pkg/formatter/pipeline_logs/json.go
@@ -1,0 +1,23 @@
+package pipeline_logs
+
+import (
+	"encoding/json"
+	"io"
+
+	"bunnyshell.com/cli/pkg/api/workflow_job"
+)
+
+// JSONFormatter formats logs as JSON
+type JSONFormatter struct{}
+
+// NewJSONFormatter creates a new JSON formatter
+func NewJSONFormatter() *JSONFormatter {
+	return &JSONFormatter{}
+}
+
+// Format outputs logs in JSON format
+func (f *JSONFormatter) Format(logs *workflow_job.WorkflowJobLogs, w io.Writer) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(logs)
+}

--- a/pkg/formatter/pipeline_logs/raw.go
+++ b/pkg/formatter/pipeline_logs/raw.go
@@ -1,0 +1,27 @@
+package pipeline_logs
+
+import (
+	"fmt"
+	"io"
+
+	"bunnyshell.com/cli/pkg/api/workflow_job"
+)
+
+// RawFormatter formats logs as plain text (messages only)
+type RawFormatter struct{}
+
+// NewRawFormatter creates a new raw formatter
+func NewRawFormatter() *RawFormatter {
+	return &RawFormatter{}
+}
+
+// Format outputs logs in raw format (just messages, no formatting)
+func (f *RawFormatter) Format(logs *workflow_job.WorkflowJobLogs, w io.Writer) error {
+	for _, step := range logs.Steps {
+		for _, log := range step.Logs {
+			fmt.Fprintln(w, log.Message)
+		}
+	}
+
+	return nil
+}

--- a/pkg/formatter/pipeline_logs/raw.go
+++ b/pkg/formatter/pipeline_logs/raw.go
@@ -15,11 +15,13 @@ func NewRawFormatter() *RawFormatter {
 	return &RawFormatter{}
 }
 
-// Format outputs logs in raw format (just messages, no formatting)
-func (f *RawFormatter) Format(logs *workflow_job.WorkflowJobLogs, w io.Writer) error {
-	for _, step := range logs.Steps {
-		for _, log := range step.Logs {
-			fmt.Fprintln(w, log.Message)
+// Format outputs pipeline logs in raw format (just messages, no formatting)
+func (f *RawFormatter) Format(logs *workflow_job.PipelineLogs, w io.Writer) error {
+	for _, job := range logs.Jobs {
+		for _, step := range job.Steps {
+			for _, log := range step.Logs {
+				fmt.Fprintln(w, log.Message)
+			}
 		}
 	}
 

--- a/pkg/formatter/pipeline_logs/stylish.go
+++ b/pkg/formatter/pipeline_logs/stylish.go
@@ -59,12 +59,6 @@ func (f *StylishFormatter) printStep(w io.Writer, step *workflow_job.LogStep) {
 		fmt.Fprintln(w, stepHeader)
 	}
 
-	// Duration if available
-	if step.StartedAt != "" && step.FinishedAt != "" {
-		duration := f.calculateDuration(step.StartedAt, step.FinishedAt)
-		fmt.Fprintf(w, "%s\n", color.New(color.Faint).Sprintf("(completed in %s)", duration))
-	}
-
 	fmt.Fprintf(w, "%s\n\n", color.New(color.Faint).Sprint(separator))
 
 	// Print logs
@@ -81,19 +75,7 @@ func (f *StylishFormatter) printLogMessage(w io.Writer, log *workflow_job.LogMes
 	timestamp := f.formatTimestamp(log.Timestamp)
 	timestampStr := color.New(color.Faint).Sprintf("  %s", timestamp)
 
-	// Colorize based on level
-	message := log.Message
-	switch log.Level {
-	case "error":
-		message = color.RedString("✘ %s", message)
-	case "warn":
-		message = color.YellowString("⚠ %s", message)
-	case "debug":
-		message = color.New(color.Faint).Sprint(message)
-	default:
-		// info or other - no special formatting
-		message = fmt.Sprintf("  %s", message)
-	}
+	message := fmt.Sprintf("  %s", log.Message)
 
 	fmt.Fprintf(w, "%s  %s\n", timestampStr, message)
 }
@@ -157,25 +139,4 @@ func (f *StylishFormatter) formatTimestamp(timestamp string) string {
 	}
 
 	return t.Format("15:04:05")
-}
-
-// calculateDuration calculates duration between two timestamps
-func (f *StylishFormatter) calculateDuration(start, end string) string {
-	startTime, err1 := time.Parse(time.RFC3339, start)
-	endTime, err2 := time.Parse(time.RFC3339, end)
-
-	if err1 != nil || err2 != nil {
-		return "unknown"
-	}
-
-	duration := endTime.Sub(startTime)
-
-	// Format duration nicely
-	if duration.Seconds() < 60 {
-		return fmt.Sprintf("%.0fs", duration.Seconds())
-	} else if duration.Minutes() < 60 {
-		return fmt.Sprintf("%.1fm", duration.Minutes())
-	} else {
-		return fmt.Sprintf("%.1fh", duration.Hours())
-	}
 }

--- a/pkg/formatter/pipeline_logs/stylish.go
+++ b/pkg/formatter/pipeline_logs/stylish.go
@@ -22,30 +22,62 @@ func NewStylishFormatter() *StylishFormatter {
 	}
 }
 
-// Format outputs logs in stylish format
-func (f *StylishFormatter) Format(logs *workflow_job.WorkflowJobLogs, w io.Writer) error {
-	// Print header
-	fmt.Fprintf(w, "\nWorkflow Job: %s\n", logs.WorkflowJobID)
-	fmt.Fprintf(w, "Status: %s\n\n", f.colorizeStatus(logs.Status))
-
-	// Print each step
-	for _, step := range logs.Steps {
-		f.printStep(w, &step)
+// Format outputs pipeline logs in stylish format
+func (f *StylishFormatter) Format(logs *workflow_job.PipelineLogs, w io.Writer) error {
+	if logs.WorkflowID != "" {
+		fmt.Fprintf(w, "\nWorkflow: %s\n", logs.WorkflowID)
 	}
 
-	// Print summary
+	for i, job := range logs.Jobs {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		f.printJobHeader(w, &job)
+
+		for _, step := range job.Steps {
+			f.printStep(w, &step)
+		}
+	}
+
 	f.printSummary(w, logs)
 
 	return nil
 }
 
+// printJobHeader prints a header for each workflow job
+func (f *StylishFormatter) printJobHeader(w io.Writer, job *workflow_job.WorkflowJobLogs) {
+	separator := strings.Repeat("═", 70)
+	fmt.Fprintf(w, "\n%s\n", color.New(color.FgCyan, color.Bold).Sprint(separator))
+
+	statusIcon := f.getStatusIcon(job.Status)
+	jobLabel := job.WorkflowJobID
+	if job.JobName != "" {
+		jobLabel = job.JobName
+	}
+
+	header := fmt.Sprintf("%s Job: %s", statusIcon, jobLabel)
+
+	switch job.Status {
+	case "success":
+		fmt.Fprintln(w, color.New(color.FgCyan, color.Bold).Sprint(header))
+	case "failed":
+		fmt.Fprintln(w, color.New(color.FgRed, color.Bold).Sprint(header))
+	case "running":
+		fmt.Fprintln(w, color.New(color.FgYellow, color.Bold).Sprint(header))
+	default:
+		fmt.Fprintln(w, color.New(color.Bold).Sprint(header))
+	}
+
+	fmt.Fprintf(w, "%s  %s\n", color.New(color.Faint).Sprintf("  ID: %s", job.WorkflowJobID),
+		color.New(color.Faint).Sprintf("Status: %s", f.colorizeStatus(job.Status)))
+	fmt.Fprintf(w, "%s\n", color.New(color.FgCyan, color.Bold).Sprint(separator))
+}
+
 // printStep prints a single step with its logs
 func (f *StylishFormatter) printStep(w io.Writer, step *workflow_job.LogStep) {
-	// Step header with separator
 	separator := strings.Repeat("━", 70)
 	fmt.Fprintf(w, "%s\n", color.New(color.Faint).Sprint(separator))
 
-	// Step name with status indicator
 	statusIcon := f.getStatusIcon(step.Status)
 	stepHeader := fmt.Sprintf("%s Step: %s", statusIcon, step.Name)
 
@@ -61,7 +93,6 @@ func (f *StylishFormatter) printStep(w io.Writer, step *workflow_job.LogStep) {
 
 	fmt.Fprintf(w, "%s\n\n", color.New(color.Faint).Sprint(separator))
 
-	// Print logs
 	for _, log := range step.Logs {
 		f.printLogMessage(w, &log)
 	}
@@ -71,7 +102,6 @@ func (f *StylishFormatter) printStep(w io.Writer, step *workflow_job.LogStep) {
 
 // printLogMessage prints a single log message
 func (f *StylishFormatter) printLogMessage(w io.Writer, log *workflow_job.LogMessage) {
-	// Format timestamp (HH:MM:SS)
 	timestamp := f.formatTimestamp(log.Timestamp)
 	timestampStr := color.New(color.Faint).Sprintf("  %s", timestamp)
 
@@ -81,23 +111,28 @@ func (f *StylishFormatter) printLogMessage(w io.Writer, log *workflow_job.LogMes
 }
 
 // printSummary prints summary information
-func (f *StylishFormatter) printSummary(w io.Writer, logs *workflow_job.WorkflowJobLogs) {
+func (f *StylishFormatter) printSummary(w io.Writer, logs *workflow_job.PipelineLogs) {
 	separator := strings.Repeat("━", 70)
 	fmt.Fprintf(w, "%s\n\n", color.New(color.Faint).Sprint(separator))
 
-	// Count total logs
 	totalLogs := 0
-	for _, step := range logs.Steps {
-		totalLogs += len(step.Logs)
+	totalJobs := len(logs.Jobs)
+	failedJobs := 0
+	for _, job := range logs.Jobs {
+		if job.Status == "failed" {
+			failedJobs++
+		}
+		for _, step := range job.Steps {
+			totalLogs += len(step.Logs)
+		}
 	}
 
-	fmt.Fprintf(w, "Pipeline %s\n", f.colorizeStatus(logs.Status))
+	fmt.Fprintf(w, "Jobs: %d", totalJobs)
+	if failedJobs > 0 {
+		fmt.Fprintf(w, " (%s)", color.RedString("%d failed", failedJobs))
+	}
+	fmt.Fprintln(w)
 	fmt.Fprintf(w, "Total log lines: %d\n", totalLogs)
-
-	if logs.Pagination.HasMore {
-		fmt.Fprintf(w, "\n%s\n", color.YellowString("⚠ More logs available (showing %d of %d)",
-			logs.Pagination.Offset+totalLogs, logs.Pagination.Total))
-	}
 }
 
 // getStatusIcon returns an icon for the status
@@ -134,7 +169,6 @@ func (f *StylishFormatter) colorizeStatus(status string) string {
 func (f *StylishFormatter) formatTimestamp(timestamp string) string {
 	t, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
-		// Fallback to original if parsing fails
 		return timestamp
 	}
 

--- a/pkg/formatter/pipeline_logs/stylish.go
+++ b/pkg/formatter/pipeline_logs/stylish.go
@@ -1,0 +1,181 @@
+package pipeline_logs
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"bunnyshell.com/cli/pkg/api/workflow_job"
+	"github.com/fatih/color"
+)
+
+// StylishFormatter formats logs with colors and visual hierarchy
+type StylishFormatter struct {
+	colorEnabled bool
+}
+
+// NewStylishFormatter creates a new stylish formatter
+func NewStylishFormatter() *StylishFormatter {
+	return &StylishFormatter{
+		colorEnabled: true,
+	}
+}
+
+// Format outputs logs in stylish format
+func (f *StylishFormatter) Format(logs *workflow_job.WorkflowJobLogs, w io.Writer) error {
+	// Print header
+	fmt.Fprintf(w, "\nWorkflow Job: %s\n", logs.WorkflowJobID)
+	fmt.Fprintf(w, "Status: %s\n\n", f.colorizeStatus(logs.Status))
+
+	// Print each step
+	for _, step := range logs.Steps {
+		f.printStep(w, &step)
+	}
+
+	// Print summary
+	f.printSummary(w, logs)
+
+	return nil
+}
+
+// printStep prints a single step with its logs
+func (f *StylishFormatter) printStep(w io.Writer, step *workflow_job.LogStep) {
+	// Step header with separator
+	separator := strings.Repeat("━", 70)
+	fmt.Fprintf(w, "%s\n", color.New(color.Faint).Sprint(separator))
+
+	// Step name with status indicator
+	statusIcon := f.getStatusIcon(step.Status)
+	stepHeader := fmt.Sprintf("%s Step: %s", statusIcon, step.Name)
+
+	if step.Status == "success" {
+		fmt.Fprintln(w, color.GreenString(stepHeader))
+	} else if step.Status == "failed" {
+		fmt.Fprintln(w, color.RedString(stepHeader))
+	} else if step.Status == "running" {
+		fmt.Fprintln(w, color.YellowString(stepHeader))
+	} else {
+		fmt.Fprintln(w, stepHeader)
+	}
+
+	// Duration if available
+	if step.StartedAt != "" && step.FinishedAt != "" {
+		duration := f.calculateDuration(step.StartedAt, step.FinishedAt)
+		fmt.Fprintf(w, "%s\n", color.New(color.Faint).Sprintf("(completed in %s)", duration))
+	}
+
+	fmt.Fprintf(w, "%s\n\n", color.New(color.Faint).Sprint(separator))
+
+	// Print logs
+	for _, log := range step.Logs {
+		f.printLogMessage(w, &log)
+	}
+
+	fmt.Fprintln(w)
+}
+
+// printLogMessage prints a single log message
+func (f *StylishFormatter) printLogMessage(w io.Writer, log *workflow_job.LogMessage) {
+	// Format timestamp (HH:MM:SS)
+	timestamp := f.formatTimestamp(log.Timestamp)
+	timestampStr := color.New(color.Faint).Sprintf("  %s", timestamp)
+
+	// Colorize based on level
+	message := log.Message
+	switch log.Level {
+	case "error":
+		message = color.RedString("✘ %s", message)
+	case "warn":
+		message = color.YellowString("⚠ %s", message)
+	case "debug":
+		message = color.New(color.Faint).Sprint(message)
+	default:
+		// info or other - no special formatting
+		message = fmt.Sprintf("  %s", message)
+	}
+
+	fmt.Fprintf(w, "%s  %s\n", timestampStr, message)
+}
+
+// printSummary prints summary information
+func (f *StylishFormatter) printSummary(w io.Writer, logs *workflow_job.WorkflowJobLogs) {
+	separator := strings.Repeat("━", 70)
+	fmt.Fprintf(w, "%s\n\n", color.New(color.Faint).Sprint(separator))
+
+	// Count total logs
+	totalLogs := 0
+	for _, step := range logs.Steps {
+		totalLogs += len(step.Logs)
+	}
+
+	fmt.Fprintf(w, "Pipeline %s\n", f.colorizeStatus(logs.Status))
+	fmt.Fprintf(w, "Total log lines: %d\n", totalLogs)
+
+	if logs.Pagination.HasMore {
+		fmt.Fprintf(w, "\n%s\n", color.YellowString("⚠ More logs available (showing %d of %d)",
+			logs.Pagination.Offset+totalLogs, logs.Pagination.Total))
+	}
+}
+
+// getStatusIcon returns an icon for the status
+func (f *StylishFormatter) getStatusIcon(status string) string {
+	switch status {
+	case "success":
+		return "✓"
+	case "failed":
+		return "✗"
+	case "running":
+		return "⟳"
+	case "pending":
+		return "○"
+	default:
+		return "•"
+	}
+}
+
+// colorizeStatus returns a colorized status string
+func (f *StylishFormatter) colorizeStatus(status string) string {
+	switch status {
+	case "success", "completed":
+		return color.GreenString(status)
+	case "failed":
+		return color.RedString(status)
+	case "running":
+		return color.YellowString(status)
+	default:
+		return status
+	}
+}
+
+// formatTimestamp formats ISO timestamp to HH:MM:SS
+func (f *StylishFormatter) formatTimestamp(timestamp string) string {
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		// Fallback to original if parsing fails
+		return timestamp
+	}
+
+	return t.Format("15:04:05")
+}
+
+// calculateDuration calculates duration between two timestamps
+func (f *StylishFormatter) calculateDuration(start, end string) string {
+	startTime, err1 := time.Parse(time.RFC3339, start)
+	endTime, err2 := time.Parse(time.RFC3339, end)
+
+	if err1 != nil || err2 != nil {
+		return "unknown"
+	}
+
+	duration := endTime.Sub(startTime)
+
+	// Format duration nicely
+	if duration.Seconds() < 60 {
+		return fmt.Sprintf("%.0fs", duration.Seconds())
+	} else if duration.Minutes() < 60 {
+		return fmt.Sprintf("%.1fm", duration.Minutes())
+	} else {
+		return fmt.Sprintf("%.1fh", duration.Hours())
+	}
+}

--- a/pkg/formatter/pipeline_logs/yaml.go
+++ b/pkg/formatter/pipeline_logs/yaml.go
@@ -1,0 +1,25 @@
+package pipeline_logs
+
+import (
+	"io"
+
+	"bunnyshell.com/cli/pkg/api/workflow_job"
+	"gopkg.in/yaml.v3"
+)
+
+// YAMLFormatter formats logs as YAML
+type YAMLFormatter struct{}
+
+// NewYAMLFormatter creates a new YAML formatter
+func NewYAMLFormatter() *YAMLFormatter {
+	return &YAMLFormatter{}
+}
+
+// Format outputs logs in YAML format
+func (f *YAMLFormatter) Format(logs *workflow_job.WorkflowJobLogs, w io.Writer) error {
+	encoder := yaml.NewEncoder(w)
+	encoder.SetIndent(2)
+	defer encoder.Close()
+
+	return encoder.Encode(logs)
+}

--- a/pkg/formatter/pipeline_logs/yaml.go
+++ b/pkg/formatter/pipeline_logs/yaml.go
@@ -15,8 +15,8 @@ func NewYAMLFormatter() *YAMLFormatter {
 	return &YAMLFormatter{}
 }
 
-// Format outputs logs in YAML format
-func (f *YAMLFormatter) Format(logs *workflow_job.WorkflowJobLogs, w io.Writer) error {
+// Format outputs pipeline logs in YAML format
+func (f *YAMLFormatter) Format(logs *workflow_job.PipelineLogs, w io.Writer) error {
 	encoder := yaml.NewEncoder(w)
 	encoder.SetIndent(2)
 	defer encoder.Close()

--- a/pkg/formatter/stylish.pipeline.go
+++ b/pkg/formatter/stylish.pipeline.go
@@ -9,18 +9,24 @@ import (
 )
 
 func tabulatePipelineCollection(writer *tabwriter.Writer, data *sdk.PaginatedPipelineCollection) {
-	fmt.Fprintf(writer, "%v\t %v\t %v\t %v\t %v\n", "PipelineID", "EnvironmentID", "OrganizationID", "Description", "Status")
+	fmt.Fprintf(writer, "%v\t %v\t %v\t %v\t %v\t %v\n", "PipelineID", "EnvironmentID", "OrganizationID", "Description", "Status", "CreatedAt")
 
 	if data.Embedded != nil {
 		for _, item := range data.Embedded.Item {
+			createdAt := ""
+			if item.HasCreatedAt() {
+				createdAt = item.GetCreatedAt().Local().Format("2006-01-02 15:04:05")
+			}
+
 			fmt.Fprintf(
 				writer,
-				"%v\t %v\t %v\t %v\t %v\n",
+				"%v\t %v\t %v\t %v\t %v\t %v\n",
 				item.GetId(),
 				item.GetEnvironment(),
 				item.GetOrganization(),
 				item.GetDescription(),
 				item.GetStatus(),
+				createdAt,
 			)
 		}
 	}


### PR DESCRIPTION
## Summary

- Add `bns pipeline logs` command to view structured logs from pipeline job executions
- Add `bns pipeline jobs` command to list jobs within a pipeline
- Add `createdAt` column to `bns pipeline list` output

## New Commands

### `bns pipeline logs`

Fetches and displays structured logs from workflow job executions (build, deploy, etc.).

```bash
# View latest pipeline logs (interactive job selection)
bns pipeline logs --environment ENV_ID

# View only failed jobs
bns pipeline logs --environment ENV_ID --failed

# View a specific pipeline
bns pipeline logs --id PIPELINE_ID

# View a specific job directly
bns pipeline logs --job JOB_ID

# Follow active pipeline logs
bns pipeline logs --environment ENV_ID -f

# Filter by step name
bns pipeline logs --job JOB_ID --step build

# Show last 50 lines per step
bns pipeline logs --job JOB_ID --tail 50

# Output formats: stylish (default), json, yaml, raw
bns pipeline logs --job JOB_ID -o json
```

**Flags:**
| Flag | Description |
|------|-------------|
| `--environment` | Environment ID (discovers latest pipeline, lists jobs) |
| `--id` | Pipeline ID (lists jobs from specific pipeline) |
| `--job` | Job ID (fetches logs directly, skips selection) |
| `--failed` | Show only failed jobs |
| `-f, --follow` | Stream logs in real-time |
| `--step` | Filter by step name |
| `--tail` | Show last N lines per step |
| `-o, --output` | Output format: stylish, json, yaml, raw |

### `bns pipeline jobs`

Lists all jobs within a pipeline with their status and duration.

```bash
bns pipeline jobs --id PIPELINE_ID
bns pipeline jobs --id PIPELINE_ID -o json
```

## Changes

### New files
- `cmd/pipeline/logs.go` — Pipeline logs command with interactive job selection
- `cmd/pipeline/jobs.go` — Pipeline jobs listing command
- `pkg/api/workflow_job/logs.go` — API client for workflow job logs and info
- `pkg/api/workflow/item.go` — SDK wrapper for workflow view
- `pkg/api/workflow/list.go` — SDK wrapper for workflow list
- `pkg/formatter/pipeline_logs/stylish.go` — Color-coded log output with step headers
- `pkg/formatter/pipeline_logs/json.go` — Structured JSON output
- `pkg/formatter/pipeline_logs/yaml.go` — YAML output
- `pkg/formatter/pipeline_logs/raw.go` — Plain text output

### Modified files
- `pkg/formatter/stylish.pipeline.go` — Added `CreatedAt` column to pipeline list

## Dependencies

- Requires backend MR !1207 (`/v1/workflow_jobs/{id}` and `/v1/workflow_jobs/{id}/logs` endpoints)
- Uses local SDK with `WorkflowJobItem` model (`go.mod` replace directive must be removed once SDK is published)

## Test plan

- [ ] `bns pipeline logs --environment <ID>` lists jobs and shows logs
- [ ] `bns pipeline logs --environment <ID> --failed` filters to failed jobs only
- [ ] `bns pipeline logs --id <PIPELINE_ID>` works without environment
- [ ] `bns pipeline logs --job <JOB_ID>` fetches logs directly
- [ ] `bns pipeline jobs --id <PIPELINE_ID>` shows job table
- [ ] All output formats work (stylish, json, yaml, raw)
- [ ] `--step` and `--tail` flags filter correctly
- [ ] Context fallback works when environment is set in profile